### PR TITLE
Miller Loop gadgets (depends on #16)

### DIFF
--- a/libzecale/circuits/fields/fp12_2over3over2_gadgets.hpp
+++ b/libzecale/circuits/fields/fp12_2over3over2_gadgets.hpp
@@ -30,7 +30,7 @@ public:
         libsnark::protoboard<FieldT> &pb, const std::string &annotation_prefix);
     Fp12_2over3over2_variable(
         libsnark::protoboard<FieldT> &pb,
-        const Fp12T &v,
+        const Fp12T &el,
         const std::string &annotation_prefix);
 
     Fp12_2over3over2_variable(
@@ -40,7 +40,7 @@ public:
         const std::string &annotation_prefix);
 
     Fp12T get_element() const;
-    void generate_r1cs_witness(const Fp12T &v);
+    void generate_r1cs_witness(const Fp12T &el);
 };
 
 /// Follows implementation in libff::Fp12_2over3over2_model, which is based on

--- a/libzecale/circuits/fields/fp12_2over3over2_gadgets.hpp
+++ b/libzecale/circuits/fields/fp12_2over3over2_gadgets.hpp
@@ -1,0 +1,168 @@
+// Copyright (c) 2015-2020 Clearmatics Technologies Ltd
+//
+// SPDX-License-Identifier: LGPL-3.0+
+
+#ifndef __ZECALE_CIRCUITS_FIELDS_FP12_2OVER3OVER2_GADGETS_HPP__
+#define __ZECALE_CIRCUITS_FIELDS_FP12_2OVER3OVER2_GADGETS_HPP__
+
+#include "libzecale/circuits/fields/fp6_3over2_gadgets.hpp"
+
+namespace libzecale
+{
+
+template<typename Fp12T>
+class Fp12_2over3over2_variable : public libsnark::gadget<typename Fp12T::my_Fp>
+{
+public:
+    using FieldT = typename Fp12T::my_Fp;
+    using Fp6T = typename Fp12T::my_Fp6;
+
+    Fp6_3over2_variable<Fp6T> _c0;
+    Fp6_3over2_variable<Fp6T> _c1;
+
+    Fp12_2over3over2_variable(
+        libsnark::protoboard<FieldT> &pb, const std::string &annotation_prefix);
+    Fp12_2over3over2_variable(
+        libsnark::protoboard<FieldT> &pb,
+        const Fp12T &v,
+        const std::string &annotation_prefix);
+
+    Fp12_2over3over2_variable(
+        libsnark::protoboard<FieldT> &pb,
+        const Fp6_3over2_variable<Fp6T> &c0,
+        const Fp6_3over2_variable<Fp6T> &c1,
+        const std::string &annotation_prefix);
+
+    Fp12T get_element() const;
+    void generate_r1cs_witness(const Fp12T &v);
+};
+
+/// Follows implementation in libff::Fp12_2over3over2_model, which is based on
+/// Devegili OhEig Scott Dahab "Multiplication and Squaring on Pairing-Friendly
+/// Fields"; Section 3".
+///
+/// As an order 2 extension of Fp6, Fp12 has elements of the form
+///   (a0, a1) = a0 + w.a1 for a0, a1 in Fp6.
+/// so that
+///   (a0, a1)^2 = (a0^2 + v.a1^2, 2.a0.a1) (v == w^2, in Fp6)
+/// But
+///   a0^2 + a1^2.v = (a0 + a1).(a0 + v.a1) - v.(a0.a1) - a0.a1,
+/// so that (a0, a1)^2 can be computed with 2 multiplications. (Note,
+/// multiplication by v in Fp6 can be done cheaply - see
+/// Fp12_2over3over2_variable::mul_by_non_residue).
+template<typename Fp12T>
+class Fp12_2over3over2_square_gadget
+    : public libsnark::gadget<typename Fp12T::my_Fp>
+{
+public:
+    using FieldT = typename Fp12T::my_Fp;
+    using Fp6T = typename Fp12T::my_Fp6;
+
+    // Let
+    //
+    //     \alpha = _A.c0 * _A.c1, and
+    //     \beta = (_A.c0 + _A.c1)*(_A.c0 + v*_A.c1)
+    //
+    // then (by the above optimization), we have
+    //
+    //     _result.c1 = 2 . \alpha
+    //       <=>  _alpha = _result.c1 * 2.inverse()
+    //
+    //     _result.c0 = \beta - v.\alpha - \alpha
+    //       <=>  \beta = _result.c0 + v.\alpha - \alpha
+    Fp12_2over3over2_variable<Fp12T> _A;
+    Fp12_2over3over2_variable<Fp12T> _result;
+    Fp6_3over2_mul_gadget<Fp6T> _alpha;
+    Fp6_3over2_mul_gadget<Fp6T> _beta;
+
+    Fp12_2over3over2_square_gadget(
+        libsnark::protoboard<FieldT> &pb,
+        const Fp12_2over3over2_variable<Fp12T> &A,
+        const Fp12_2over3over2_variable<Fp12T> &result,
+        const std::string &annotation_prefix);
+
+    const Fp12_2over3over2_variable<Fp12T> &result() const;
+    void generate_r1cs_constraints();
+    void generate_r1cs_witness();
+
+    /// Multiply an element in Fq6 by Fq12::non_residue. Let c = c0 + c1.v +
+    /// c2.v^2 be an element of Fq6T, where v is a root of:
+    ///   v^3 - Fq6::non_residue
+    /// Return v * c.
+    ///
+    /// Note, this does not save any complexity in the final circuit since
+    /// Fp6_3over2_variable::operator*(const Fp6T &) can be implemented as just
+    /// linear combinations.
+    static Fp6_3over2_variable<Fp6T> mul_by_non_residue(
+        libsnark::protoboard<FieldT> &pb,
+        const Fp6_3over2_variable<Fp6T> &c,
+        const std::string &annotation_prefix);
+};
+
+/// Optimal multiplication in Fp12 of z = ((z0, z1, z2), (z3, z4, z5)), by some
+/// sparse x = ((x0, 0, x2), (0, x4, 0)). Follows the structure of
+/// libff::Fp12_2over3over2<Fp12T>::mul_by_024 (See
+/// libff/algebra/fields/fp12_2over3over2.tcc).
+template<typename Fp12T>
+class Fp12_2over3over2_mul_by_024_gadget
+    : public libsnark::gadget<typename Fp12T::my_Fp>
+{
+public:
+    using FieldT = typename Fp12T::my_Fp;
+    using Fp6T = typename Fp12T::my_Fp6;
+    using Fp2T = typename Fp12T::my_Fp2;
+
+    Fp12_2over3over2_variable<Fp12T> _Z;
+    libsnark::Fp2_variable<Fp2T> _X_0;
+    libsnark::Fp2_variable<Fp2T> _X_2;
+    libsnark::Fp2_variable<Fp2T> _X_4;
+
+    // out_z0 = z0*x0 + non_residue * ( z1*x2 + z4*x4 )
+    libsnark::Fp2_mul_gadget<Fp2T> _z1_x2;
+    libsnark::Fp2_mul_gadget<Fp2T> _z4_x4;
+    libsnark::Fp2_mul_gadget<Fp2T> _z0_x0;
+
+    // out_z1 = z1*x0 + non_residue * ( z2*x2 + z5*x4 )
+    libsnark::Fp2_mul_gadget<Fp2T> _z2_x2;
+    libsnark::Fp2_mul_gadget<Fp2T> _z5_x4;
+    libsnark::Fp2_mul_gadget<Fp2T> _z1_x0;
+
+    // out_z2 = z0*x2 + z2*x0 + z3*x4
+    libsnark::Fp2_mul_gadget<Fp2T> _z3_x4;
+    libsnark::Fp2_mul_gadget<Fp2T> _z02_x02;
+
+    // out_z3 = z3*x0 + non_residue * (z2*x4 + z4*x2)
+    libsnark::Fp2_mul_gadget<Fp2T> _z3_x0;
+    libsnark::Fp2_mul_gadget<Fp2T> _z24_x24;
+
+    // out_z4 = z0*x4 + z4*x0 + non_residue * z5*x2
+    libsnark::Fp2_mul_gadget<Fp2T> _z5_x2;
+    libsnark::Fp2_mul_gadget<Fp2T> _z04_x04;
+
+    // S = z1_x0 - z1_x2 - z3_x0 - z3*x4 - z5_x2 - z5*x4
+    // out_z5 = z1*x4 + z3*x2 + z5*x0
+    //        = (z1 + z3 + z5)*(x0 + x2 + x4) - S
+    libsnark::Fp2_variable<Fp2T> _S;
+    libsnark::Fp2_mul_gadget<Fp2T> _z1z3z5_times_x0x2x4;
+
+    Fp12_2over3over2_variable<Fp12T> _result;
+
+    Fp12_2over3over2_mul_by_024_gadget(
+        libsnark::protoboard<FieldT> &pb,
+        const Fp12_2over3over2_variable<Fp12T> &A,
+        const libsnark::Fp2_variable<Fp2T> &B_ell_0,
+        const libsnark::Fp2_variable<Fp2T> &B_ell_vv,
+        const libsnark::Fp2_variable<Fp2T> &B_ell_vw,
+        const Fp12_2over3over2_variable<Fp12T> &result,
+        const std::string &annotation_prefix);
+
+    const Fp12_2over3over2_variable<Fp12T> &result() const;
+    void generate_r1cs_constraints();
+    void generate_r1cs_witness();
+};
+
+} // namespace libzecale
+
+#include "libzecale/circuits/fields/fp12_2over3over2_gadgets.tcc"
+
+#endif // __ZECALE_CIRCUITS_FIELDS_FP12_2OVER3OVER2_GADGETS_HPP__

--- a/libzecale/circuits/fields/fp12_2over3over2_gadgets.tcc
+++ b/libzecale/circuits/fields/fp12_2over3over2_gadgets.tcc
@@ -1,0 +1,366 @@
+// Copyright (c) 2015-2020 Clearmatics Technologies Ltd
+//
+// SPDX-License-Identifier: LGPL-3.0+
+
+#ifndef __ZECALE_CIRCUITS_FIELDS_FP12_2OVER3OVER2_GADGETS_TCC__
+#define __ZECALE_CIRCUITS_FIELDS_FP12_2OVER3OVER2_GADGETS_TCC__
+
+#include "libzecale/circuits/fields/fp12_2over3over2_gadgets.hpp"
+
+namespace libzecale
+{
+
+// Fp12_2over3over2_variable methods
+
+template<typename Fp12T>
+Fp12_2over3over2_variable<Fp12T>::Fp12_2over3over2_variable(
+    libsnark::protoboard<FieldT> &pb, const std::string &annotation_prefix)
+    : libsnark::gadget<FieldT>(pb, annotation_prefix)
+    , _c0(pb, FMT(annotation_prefix, " c0"))
+    , _c1(pb, FMT(annotation_prefix, " c1"))
+{
+}
+
+template<typename Fp12T>
+Fp12_2over3over2_variable<Fp12T>::Fp12_2over3over2_variable(
+    libsnark::protoboard<FieldT> &pb,
+    const Fp12T &v,
+    const std::string &annotation_prefix)
+    : libsnark::gadget<FieldT>(pb, annotation_prefix)
+    , _c0(pb, v.c0, FMT(annotation_prefix, " c0"))
+    , _c1(pb, v.c1, FMT(annotation_prefix, " c1"))
+{
+}
+
+template<typename Fp12T>
+Fp12_2over3over2_variable<Fp12T>::Fp12_2over3over2_variable(
+    libsnark::protoboard<FieldT> &pb,
+    const Fp6_3over2_variable<Fp6T> &c0,
+    const Fp6_3over2_variable<Fp6T> &c1,
+    const std::string &annotation_prefix)
+    : libsnark::gadget<FieldT>(pb, annotation_prefix), _c0(c0), _c1(c1)
+{
+}
+
+template<typename Fp12T>
+Fp12T Fp12_2over3over2_variable<Fp12T>::get_element() const
+{
+    return Fp12T(_c0.get_element(), _c1.get_element());
+}
+
+template<typename Fp12T>
+void Fp12_2over3over2_variable<Fp12T>::generate_r1cs_witness(const Fp12T &v)
+{
+    _c0.generate_r1cs_witness(v.c0);
+    _c1.generate_r1cs_witness(v.c1);
+}
+
+// Fp12_2over3over2_square_gadget methods
+
+template<typename Fp12T>
+Fp12_2over3over2_square_gadget<Fp12T>::Fp12_2over3over2_square_gadget(
+    libsnark::protoboard<FieldT> &pb,
+    const Fp12_2over3over2_variable<Fp12T> &A,
+    const Fp12_2over3over2_variable<Fp12T> &result,
+    const std::string &annotation_prefix)
+    : libsnark::gadget<FieldT>(pb, annotation_prefix)
+    , _A(A)
+    , _result(result)
+    , _alpha(
+          pb,
+          _A._c0,
+          _A._c1,
+          _result._c1 * (FieldT("2").inverse()),
+          FMT(annotation_prefix, " a0*a1"))
+    , _beta(
+          pb,
+          _A._c0 + _A._c1,
+          _A._c0 +
+              mul_by_non_residue(pb, _A._c1, FMT(annotation_prefix, " a1*v")),
+          _result._c0 +
+              mul_by_non_residue(
+                  pb, _alpha._result, FMT(annotation_prefix, " alpha*v")) +
+              _alpha._result,
+          FMT(annotation_prefix, " (a0+a1)(a0+v.a1)"))
+{
+}
+
+template<typename Fp12T>
+const Fp12_2over3over2_variable<Fp12T>
+    &Fp12_2over3over2_square_gadget<Fp12T>::result() const
+{
+    return _result;
+}
+
+template<typename Fp12T>
+void Fp12_2over3over2_square_gadget<Fp12T>::generate_r1cs_constraints()
+{
+    _alpha.generate_r1cs_constraints();
+    _beta.generate_r1cs_constraints();
+}
+
+template<typename Fp12T>
+void Fp12_2over3over2_square_gadget<Fp12T>::generate_r1cs_witness()
+{
+    const Fp6T a0 = _A._c0.get_element();
+    const Fp6T a1 = _A._c1.get_element();
+    const Fp6T alpha = a0 * a1;
+    _result._c1.generate_r1cs_witness(alpha + alpha);
+    _alpha.generate_r1cs_witness();
+
+    const Fp6T beta = (a0 + a1) * (a0 + Fp12T::mul_by_non_residue(a1));
+    _result._c0.generate_r1cs_witness(
+        beta - Fp12T::mul_by_non_residue(alpha) - alpha);
+    _beta._A.evaluate();
+    _beta._B.evaluate();
+    _beta.generate_r1cs_witness();
+}
+
+template<typename Fp12T>
+Fp6_3over2_variable<typename Fp12T::my_Fp6> Fp12_2over3over2_square_gadget<
+    Fp12T>::
+    mul_by_non_residue(
+        libsnark::protoboard<FieldT> &pb,
+        const Fp6_3over2_variable<typename Fp12T::my_Fp6> &c,
+        const std::string &annotation_prefix)
+{
+    return Fp6_3over2_variable<Fp6T>(
+        pb, c._c2 * Fp12T::non_residue, c._c0, c._c1, annotation_prefix);
+}
+
+// Fp12_2over3over2_mul_by_024_gadget methods
+
+template<typename Fp12T>
+Fp12_2over3over2_mul_by_024_gadget<Fp12T>::Fp12_2over3over2_mul_by_024_gadget(
+    libsnark::protoboard<FieldT> &pb,
+    const Fp12_2over3over2_variable<Fp12T> &Z,
+    const libsnark::Fp2_variable<Fp2T> &X_0,
+    const libsnark::Fp2_variable<Fp2T> &X_2,
+    const libsnark::Fp2_variable<Fp2T> &X_4,
+    const Fp12_2over3over2_variable<Fp12T> &result,
+    const std::string &annotation_prefix)
+    : libsnark::gadget<FieldT>(pb, annotation_prefix)
+    , _Z(Z)
+    , _X_0(X_0)
+    , _X_2(X_2)
+    , _X_4(X_4)
+    // out_z0 = z0*x0 + non_residue * ( z1*x2 + z4*x4 )
+    // => z0 * x0 = out_z0 - non_residue * ( z1*x2 + z4*x4 )
+    , _z1_x2(
+          pb,
+          Z._c0._c1,
+          X_2,
+          libsnark::Fp2_variable<Fp2T>(pb, FMT(annotation_prefix, "_z1_x2")),
+          FMT(annotation_prefix, "z1_x2"))
+    , _z4_x4(
+          pb,
+          Z._c1._c1,
+          X_4,
+          libsnark::Fp2_variable<Fp2T>(pb, FMT(annotation_prefix, "_z4_x4")),
+          FMT(annotation_prefix, "z4_x4"))
+    , _z0_x0(
+          pb,
+          Z._c0._c0,
+          X_0,
+          result._c0._c0 +
+              ((_z1_x2.result + _z4_x4.result) * -Fp6T::non_residue),
+          FMT(annotation_prefix, "z0_x0"))
+    // out_z1 = z1*x0 + non_residue * ( z2*x2 + z5*x4 )
+    // => z1 * z0 = out_z1 - non_residue * ( z2*x2 + z5*x4 )
+    , _z2_x2(
+          pb,
+          Z._c0._c2,
+          X_2,
+          libsnark::Fp2_variable<Fp2T>(pb, FMT(annotation_prefix, "_z2_x2")),
+          FMT(annotation_prefix, "z2_x2"))
+    , _z5_x4(
+          pb,
+          Z._c1._c2,
+          X_4,
+          libsnark::Fp2_variable<Fp2T>(pb, FMT(annotation_prefix, "_z5_x4")),
+          FMT(annotation_prefix, "z5_x4"))
+    , _z1_x0(
+          pb,
+          Z._c0._c1,
+          X_0,
+          result._c0._c1 +
+              ((_z2_x2.result + _z5_x4.result) * -Fp6T::non_residue),
+          FMT(annotation_prefix, "z1_x0"))
+    // z0*x2 + z2*x0 = (z0 + z2)*(x0 + x2) - z0*x0 - z2*x2
+    // out_z2 = z0*x2 + z2*x0 + z3*x4
+    //        = (z0 + z2)*(x0 + x2) - z0*x0 - z2*x2 + z3*x4
+    // => (z0 + z2)*(x0 + x2) = out_z2 + z0*x0 + z2*x2 - z3*x4
+    , _z3_x4(
+          pb,
+          Z._c1._c0,
+          X_4,
+          libsnark::Fp2_variable<Fp2T>(pb, FMT(annotation_prefix, "_z3_x4")),
+          FMT(annotation_prefix, "z3_x4"))
+    , _z02_x02(
+          pb,
+          Z._c0._c0 + Z._c0._c2,
+          X_0 + X_2,
+          result._c0._c2 + _z0_x0.result + _z2_x2.result +
+              (_z3_x4.result * -FieldT::one()),
+          FMT(annotation_prefix, "calc z02_x02"))
+    // z2*x4 + z4*x2 = (z2 + z4)*(x2 + x4) - z2*x2 - z4*x4
+    // out_z3 = z3*x0 + non_residue * (z2*x4 + z4*x2)
+    //        = z3*x0 + non_residue * ((z2 + z4)*(x2 + x4) - z2*x2 - z4*x4)
+    // => (z2 + z4)*(x2 + x4) = (out_z3 - z3*x0) / non_residue + z2*x2 + z4_x4
+    , _z3_x0(
+          pb,
+          Z._c1._c0,
+          X_0,
+          libsnark::Fp2_variable<Fp2T>(pb, FMT(annotation_prefix, "_z3_x0")),
+          FMT(annotation_prefix, "z3_x0"))
+    , _z24_x24(
+          pb,
+          Z._c0._c2 + Z._c1._c1,
+          X_2 + X_4,
+          _z2_x2.result + _z4_x4.result +
+              (result._c1._c0 + _z3_x0.result * -FieldT::one()) *
+                  Fp6T::non_residue.inverse(),
+          FMT(annotation_prefix, "z24_x24"))
+    // z0*x4 + z4*x0 = (z0 + z4)*(x0 + x4) - z0*x0 - z4*x4
+    // out_z4 = z0*x4 + z4*x0 + non_residue * z5*x2
+    //        = (z0 + z4)*(x0 + x4) - z0*x0 - z4*x4 + non_residue * z5*x2
+    // => (z0 + z4)*(x0 + x4) = out_z4 + z0*x0 + z4*x4 - non_residue * z5*x2
+    , _z5_x2(
+          pb,
+          Z._c1._c2,
+          X_2,
+          libsnark::Fp2_variable<Fp2T>(pb, FMT(annotation_prefix, "_z5_x2")),
+          FMT(annotation_prefix, "z5_x2"))
+    , _z04_x04(
+          pb,
+          Z._c0._c0 + Z._c1._c1,
+          X_0 + X_4,
+          result._c1._c1 + _z0_x0.result + _z4_x4.result +
+              _z5_x2.result * -Fp6T::non_residue,
+          FMT(annotation_prefix, "z4_x04"))
+    // S = z1_x0 + z1_x2 + z3_x0 + z3*x4 + z5_x2 + z5*x4
+    // out_z5 = z1*x4 + z3*x2 + z5*x0
+    //        = (z1 + z3 + z5)*(x0 + x2 + x4) - S
+    // => (z1 + z3 + z5)*(x0 + x2 + x4) = out_z5 + S
+    , _S(_z1_x2.result + _z1_x0.result + _z5_x4.result + _z3_x4.result +
+         _z3_x0.result + _z5_x2.result)
+    , _z1z3z5_times_x0x2x4(
+          pb,
+          Z._c0._c1 + Z._c1._c0 + Z._c1._c2,
+          X_0 + X_2 + X_4,
+          result._c1._c2 + _S,
+          FMT(annotation_prefix, "calc z1z3z5_times_x0x2x4"))
+    , _result(result)
+{
+}
+
+template<typename Fp12T>
+const Fp12_2over3over2_variable<Fp12T>
+    &Fp12_2over3over2_mul_by_024_gadget<Fp12T>::result() const
+{
+    return _result;
+}
+
+template<typename Fp12T>
+void Fp12_2over3over2_mul_by_024_gadget<Fp12T>::generate_r1cs_constraints()
+{
+    _z1_x2.generate_r1cs_constraints();
+    _z4_x4.generate_r1cs_constraints();
+    _z0_x0.generate_r1cs_constraints();
+    _z2_x2.generate_r1cs_constraints();
+    _z5_x4.generate_r1cs_constraints();
+    _z1_x0.generate_r1cs_constraints();
+    _z3_x4.generate_r1cs_constraints();
+    _z02_x02.generate_r1cs_constraints();
+    _z3_x0.generate_r1cs_constraints();
+    _z24_x24.generate_r1cs_constraints();
+    _z5_x2.generate_r1cs_constraints();
+    _z04_x04.generate_r1cs_constraints();
+    _z1z3z5_times_x0x2x4.generate_r1cs_constraints();
+}
+
+template<typename Fp12T>
+void Fp12_2over3over2_mul_by_024_gadget<Fp12T>::generate_r1cs_witness()
+{
+    const Fp2T z0 = _Z._c0._c0.get_element();
+    const Fp2T z1 = _Z._c0._c1.get_element();
+    const Fp2T z2 = _Z._c0._c2.get_element();
+    const Fp2T z3 = _Z._c1._c0.get_element();
+    const Fp2T z4 = _Z._c1._c1.get_element();
+    const Fp2T z5 = _Z._c1._c2.get_element();
+
+    const Fp2T x0 = _X_0.get_element();
+    const Fp2T x2 = _X_2.get_element();
+    const Fp2T x4 = _X_4.get_element();
+
+    // out_z0 = z0*x0 + non_residue * ( z1*x2 + z4*x4 )
+    // => z0 * x0 = out_z0 - non_residue * ( z1*x2 + z4*x4 )
+    _z1_x2.generate_r1cs_witness();
+    _z4_x4.generate_r1cs_witness();
+    const Fp2T z0_x0 = z0 * x0;
+    const Fp2T z4_x4 = _z4_x4.result.get_element();
+    _result._c0._c0.generate_r1cs_witness(
+        z0_x0 + Fp6T::non_residue * (_z1_x2.result.get_element() + z4_x4));
+    _z0_x0.generate_r1cs_witness();
+
+    // out_z1 = z1*x0 + non_residue * ( z2*x2 + z5*x4 )
+    // => z1 * z0 = out_z1 - non_residue * ( z2*x2 + z5*x4 )
+    _z2_x2.generate_r1cs_witness();
+    _z5_x4.generate_r1cs_witness();
+    const Fp2T z2_x2 = _z2_x2.result.get_element();
+    const Fp2T z1_x0 = z1 * x0;
+    _result._c0._c1.generate_r1cs_witness(
+        z1_x0 + Fp6T::non_residue * (z2_x2 + _z5_x4.result.get_element()));
+    _z1_x0.generate_r1cs_witness();
+
+    // z0*x2 + z2*x0 = (z0 + z2)*(x0 + x2) - z0*x0 - z2*x2
+    // out_z2 = z0*x2 + z2*x0 + z3*x4
+    //        = (z0 + z2)*(x0 + x2) - z0*x0 - z2*x2 + z3*x4
+    // => (z0 + z2)*(x0 + x2) = out_z2 + z0*x0 + z2*x2 - z3*x4
+    _z3_x4.generate_r1cs_witness();
+    const Fp2T z3_x4 = _z3_x4.result.get_element();
+    _result._c0._c2.generate_r1cs_witness(
+        (z0 + z2) * (x0 + x2) - z0_x0 - z2_x2 + z3_x4);
+    _z02_x02.A.evaluate();
+    _z02_x02.B.evaluate();
+    _z02_x02.generate_r1cs_witness();
+
+    // z2*x4 + z4*x2 = (z2 + z4)*(x2 + x4) - z2*x2 - z4*x4
+    // out_z3 = z3*x0 + non_residue * (z2*x4 + z4*x2)
+    //        = z3*x0 + non_residue * ((z2 + z4)*(x2 + x4) - z2*x2 - z4*x4)
+    // => (z2 + z4)*(x2 + x4) = (out_z3 - z3*x0) / non_residue + z2*x2 + z4_x4
+    _z3_x0.generate_r1cs_witness();
+    const Fp2T z3_x0 = _z3_x0.result.get_element();
+    _result._c1._c0.generate_r1cs_witness(
+        z3_x0 + Fp6T::non_residue * ((z2 + z4) * (x2 + x4) - z2_x2 - z4_x4));
+    _z24_x24.A.evaluate();
+    _z24_x24.B.evaluate();
+    _z24_x24.generate_r1cs_witness();
+
+    // z0*x4 + z4*x0 = (z0 + z4)*(x0 + x4) - z0*x0 - z4*x4
+    // out_z4 = z0*x4 + z4*x0 + non_residue * z5*x2
+    //        = (z0 + z4)*(x0 + x4) - z0*x0 - z4*x4 + non_residue * z5*x2
+    // => (z0 + z4)*(x0 + x4) = out_z4 + z0*x0 + z4*x4 - non_residue * z5*x2
+    _z5_x2.generate_r1cs_witness();
+    const Fp2T z5_x2 = _z5_x2.result.get_element();
+    _result._c1._c1.generate_r1cs_witness(
+        (z0 + z4) * (x0 + x4) - z0_x0 - z4_x4 + Fp6T::non_residue * z5_x2);
+    _z04_x04.A.evaluate();
+    _z04_x04.B.evaluate();
+    _z04_x04.generate_r1cs_witness();
+
+    // S = z1_x0 - z1_x2 - z3_x0 - z3*x4 - z5_x2 - z5*x4
+    // out_z5 = z1*x4 + z3*x2 + z5*x0
+    //        = (z1 + z3 + z5)*(x0 + x2 + x4) - S
+    // => (z1 + z3 + z5)*(x0 + x2 + x4) = out_z5 + S
+    _S.evaluate();
+    const Fp2T S = _S.get_element();
+    _result._c1._c2.generate_r1cs_witness((z1 + z3 + z5) * (x0 + x2 + x4) - S);
+    _z1z3z5_times_x0x2x4.A.evaluate();
+    _z1z3z5_times_x0x2x4.B.evaluate();
+    _z1z3z5_times_x0x2x4.generate_r1cs_witness();
+}
+
+} // namespace libzecale
+
+#endif // __ZECALE_CIRCUITS_FIELDS_FP12_2OVER3OVER2_GADGETS_TCC__

--- a/libzecale/circuits/fields/fp12_2over3over2_gadgets.tcc
+++ b/libzecale/circuits/fields/fp12_2over3over2_gadgets.tcc
@@ -24,11 +24,11 @@ Fp12_2over3over2_variable<Fp12T>::Fp12_2over3over2_variable(
 template<typename Fp12T>
 Fp12_2over3over2_variable<Fp12T>::Fp12_2over3over2_variable(
     libsnark::protoboard<FieldT> &pb,
-    const Fp12T &v,
+    const Fp12T &el,
     const std::string &annotation_prefix)
     : libsnark::gadget<FieldT>(pb, annotation_prefix)
-    , _c0(pb, v.c0, FMT(annotation_prefix, " c0"))
-    , _c1(pb, v.c1, FMT(annotation_prefix, " c1"))
+    , _c0(pb, el.c0, FMT(annotation_prefix, " c0"))
+    , _c1(pb, el.c1, FMT(annotation_prefix, " c1"))
 {
 }
 
@@ -49,10 +49,10 @@ Fp12T Fp12_2over3over2_variable<Fp12T>::get_element() const
 }
 
 template<typename Fp12T>
-void Fp12_2over3over2_variable<Fp12T>::generate_r1cs_witness(const Fp12T &v)
+void Fp12_2over3over2_variable<Fp12T>::generate_r1cs_witness(const Fp12T &el)
 {
-    _c0.generate_r1cs_witness(v.c0);
-    _c1.generate_r1cs_witness(v.c1);
+    _c0.generate_r1cs_witness(el.c0);
+    _c1.generate_r1cs_witness(el.c1);
 }
 
 // Fp12_2over3over2_square_gadget methods

--- a/libzecale/circuits/fields/fp12_2over3over2_gadgets.tcc
+++ b/libzecale/circuits/fields/fp12_2over3over2_gadgets.tcc
@@ -71,7 +71,7 @@ Fp12_2over3over2_square_gadget<Fp12T>::Fp12_2over3over2_square_gadget(
           _A._c0,
           _A._c1,
           _result._c1 * (FieldT("2").inverse()),
-          FMT(annotation_prefix, " a0*a1"))
+          FMT(annotation_prefix, " _alpha"))
     , _beta(
           pb,
           _A._c0 + _A._c1,
@@ -81,7 +81,7 @@ Fp12_2over3over2_square_gadget<Fp12T>::Fp12_2over3over2_square_gadget(
               mul_by_non_residue(
                   pb, _alpha._result, FMT(annotation_prefix, " alpha*v")) +
               _alpha._result,
-          FMT(annotation_prefix, " (a0+a1)(a0+v.a1)"))
+          FMT(annotation_prefix, " _beta"))
 {
 }
 
@@ -150,42 +150,42 @@ Fp12_2over3over2_mul_by_024_gadget<Fp12T>::Fp12_2over3over2_mul_by_024_gadget(
           pb,
           Z._c0._c1,
           X_2,
-          libsnark::Fp2_variable<Fp2T>(pb, FMT(annotation_prefix, "_z1_x2")),
-          FMT(annotation_prefix, "z1_x2"))
+          libsnark::Fp2_variable<Fp2T>(pb, FMT(annotation_prefix, " z1*x2")),
+          FMT(annotation_prefix, "_z1_x2"))
     , _z4_x4(
           pb,
           Z._c1._c1,
           X_4,
-          libsnark::Fp2_variable<Fp2T>(pb, FMT(annotation_prefix, "_z4_x4")),
-          FMT(annotation_prefix, "z4_x4"))
+          libsnark::Fp2_variable<Fp2T>(pb, FMT(annotation_prefix, " z4*x4")),
+          FMT(annotation_prefix, " _z4_x4"))
     , _z0_x0(
           pb,
           Z._c0._c0,
           X_0,
           result._c0._c0 +
               ((_z1_x2.result + _z4_x4.result) * -Fp6T::non_residue),
-          FMT(annotation_prefix, "z0_x0"))
+          FMT(annotation_prefix, " _z0_x0"))
     // out_z1 = z1*x0 + non_residue * ( z2*x2 + z5*x4 )
     // => z1 * z0 = out_z1 - non_residue * ( z2*x2 + z5*x4 )
     , _z2_x2(
           pb,
           Z._c0._c2,
           X_2,
-          libsnark::Fp2_variable<Fp2T>(pb, FMT(annotation_prefix, "_z2_x2")),
-          FMT(annotation_prefix, "z2_x2"))
+          libsnark::Fp2_variable<Fp2T>(pb, FMT(annotation_prefix, " z2*x2")),
+          FMT(annotation_prefix, " _z2_x2"))
     , _z5_x4(
           pb,
           Z._c1._c2,
           X_4,
-          libsnark::Fp2_variable<Fp2T>(pb, FMT(annotation_prefix, "_z5_x4")),
-          FMT(annotation_prefix, "z5_x4"))
+          libsnark::Fp2_variable<Fp2T>(pb, FMT(annotation_prefix, " z5*x4")),
+          FMT(annotation_prefix, " _z5_x4"))
     , _z1_x0(
           pb,
           Z._c0._c1,
           X_0,
           result._c0._c1 +
               ((_z2_x2.result + _z5_x4.result) * -Fp6T::non_residue),
-          FMT(annotation_prefix, "z1_x0"))
+          FMT(annotation_prefix, " _z1_x0"))
     // z0*x2 + z2*x0 = (z0 + z2)*(x0 + x2) - z0*x0 - z2*x2
     // out_z2 = z0*x2 + z2*x0 + z3*x4
     //        = (z0 + z2)*(x0 + x2) - z0*x0 - z2*x2 + z3*x4
@@ -194,15 +194,15 @@ Fp12_2over3over2_mul_by_024_gadget<Fp12T>::Fp12_2over3over2_mul_by_024_gadget(
           pb,
           Z._c1._c0,
           X_4,
-          libsnark::Fp2_variable<Fp2T>(pb, FMT(annotation_prefix, "_z3_x4")),
-          FMT(annotation_prefix, "z3_x4"))
+          libsnark::Fp2_variable<Fp2T>(pb, FMT(annotation_prefix, " z3*x4")),
+          FMT(annotation_prefix, " _z3_x4"))
     , _z02_x02(
           pb,
           Z._c0._c0 + Z._c0._c2,
           X_0 + X_2,
           result._c0._c2 + _z0_x0.result + _z2_x2.result +
               (_z3_x4.result * -FieldT::one()),
-          FMT(annotation_prefix, "calc z02_x02"))
+          FMT(annotation_prefix, " _z02_x02"))
     // z2*x4 + z4*x2 = (z2 + z4)*(x2 + x4) - z2*x2 - z4*x4
     // out_z3 = z3*x0 + non_residue * (z2*x4 + z4*x2)
     //        = z3*x0 + non_residue * ((z2 + z4)*(x2 + x4) - z2*x2 - z4*x4)
@@ -211,8 +211,8 @@ Fp12_2over3over2_mul_by_024_gadget<Fp12T>::Fp12_2over3over2_mul_by_024_gadget(
           pb,
           Z._c1._c0,
           X_0,
-          libsnark::Fp2_variable<Fp2T>(pb, FMT(annotation_prefix, "_z3_x0")),
-          FMT(annotation_prefix, "z3_x0"))
+          libsnark::Fp2_variable<Fp2T>(pb, FMT(annotation_prefix, " z3*x0")),
+          FMT(annotation_prefix, " _z3_x0"))
     , _z24_x24(
           pb,
           Z._c0._c2 + Z._c1._c1,
@@ -220,7 +220,7 @@ Fp12_2over3over2_mul_by_024_gadget<Fp12T>::Fp12_2over3over2_mul_by_024_gadget(
           _z2_x2.result + _z4_x4.result +
               (result._c1._c0 + _z3_x0.result * -FieldT::one()) *
                   Fp6T::non_residue.inverse(),
-          FMT(annotation_prefix, "z24_x24"))
+          FMT(annotation_prefix, " _z24_x24"))
     // z0*x4 + z4*x0 = (z0 + z4)*(x0 + x4) - z0*x0 - z4*x4
     // out_z4 = z0*x4 + z4*x0 + non_residue * z5*x2
     //        = (z0 + z4)*(x0 + x4) - z0*x0 - z4*x4 + non_residue * z5*x2
@@ -229,15 +229,15 @@ Fp12_2over3over2_mul_by_024_gadget<Fp12T>::Fp12_2over3over2_mul_by_024_gadget(
           pb,
           Z._c1._c2,
           X_2,
-          libsnark::Fp2_variable<Fp2T>(pb, FMT(annotation_prefix, "_z5_x2")),
-          FMT(annotation_prefix, "z5_x2"))
+          libsnark::Fp2_variable<Fp2T>(pb, FMT(annotation_prefix, " z5*x2")),
+          FMT(annotation_prefix, " _z5_x2"))
     , _z04_x04(
           pb,
           Z._c0._c0 + Z._c1._c1,
           X_0 + X_4,
           result._c1._c1 + _z0_x0.result + _z4_x4.result +
               _z5_x2.result * -Fp6T::non_residue,
-          FMT(annotation_prefix, "z4_x04"))
+          FMT(annotation_prefix, " _z04_x04"))
     // S = z1_x0 + z1_x2 + z3_x0 + z3*x4 + z5_x2 + z5*x4
     // out_z5 = z1*x4 + z3*x2 + z5*x0
     //        = (z1 + z3 + z5)*(x0 + x2 + x4) - S
@@ -249,7 +249,7 @@ Fp12_2over3over2_mul_by_024_gadget<Fp12T>::Fp12_2over3over2_mul_by_024_gadget(
           Z._c0._c1 + Z._c1._c0 + Z._c1._c2,
           X_0 + X_2 + X_4,
           result._c1._c2 + _S,
-          FMT(annotation_prefix, "calc z1z3z5_times_x0x2x4"))
+          FMT(annotation_prefix, " _z1z3z5_times_x0x2x4"))
     , _result(result)
 {
 }

--- a/libzecale/circuits/fields/fp6_3over2_gadgets.hpp
+++ b/libzecale/circuits/fields/fp6_3over2_gadgets.hpp
@@ -28,7 +28,7 @@ public:
 
     Fp6_3over2_variable(
         libsnark::protoboard<FieldT> &pb,
-        const Fp6_3over2_variable<Fp6T> &v,
+        const Fp6_3over2_variable<Fp6T> &el,
         const std::string &annotation_prefix);
 
     Fp6_3over2_variable(
@@ -47,7 +47,7 @@ public:
     Fp6_3over2_variable<Fp6T> operator+(const Fp6_3over2_variable<Fp6T> &other);
 
     void evaluate() const;
-    void generate_r1cs_witness(const Fp6T &v);
+    void generate_r1cs_witness(const Fp6T &el);
     Fp6T get_element() const;
 };
 
@@ -85,10 +85,10 @@ public:
     //  (a0 + a1)(b0 + b1) = c1 + v0 + v1 - non_residue * v2
     //  (a0 + a2)(b0 + b2) = c2 + v0 + v2 - v1
 
-    libsnark::Fp2_mul_gadget<Fp2T> _v1;
-    libsnark::Fp2_mul_gadget<Fp2T> _v2;
+    libsnark::Fp2_mul_gadget<Fp2T> _a1_times_b1;
+    libsnark::Fp2_mul_gadget<Fp2T> _a2_times_b2;
     libsnark::Fp2_mul_gadget<Fp2T> _a1a2_times_b1b2;
-    libsnark::Fp2_mul_gadget<Fp2T> _v0;
+    libsnark::Fp2_mul_gadget<Fp2T> _a0_times_b0;
     libsnark::Fp2_mul_gadget<Fp2T> _a0a1_times_b0b1;
     libsnark::Fp2_mul_gadget<Fp2T> _a0a2_times_b0b2;
 

--- a/libzecale/circuits/fields/fp6_3over2_gadgets.hpp
+++ b/libzecale/circuits/fields/fp6_3over2_gadgets.hpp
@@ -1,0 +1,104 @@
+// Copyright (c) 2015-2020 Clearmatics Technologies Ltd
+//
+// SPDX-License-Identifier: LGPL-3.0+
+
+#ifndef __ZECALE_CIRCUITS_FIELDS_FP6_3OVER2_GADGETS_HPP__
+#define __ZECALE_CIRCUITS_FIELDS_FP6_3OVER2_GADGETS_HPP__
+
+#include <libff/algebra/curves/public_params.hpp>
+#include <libsnark/gadgetlib1/gadget.hpp>
+#include <libsnark/gadgetlib1/gadgets/fields/fp2_gadgets.hpp>
+
+namespace libzecale
+{
+
+template<typename Fp6T>
+class Fp6_3over2_variable : public libsnark::gadget<typename Fp6T::my_Fp>
+{
+public:
+    using FieldT = typename Fp6T::my_Fp;
+    using Fp2T = typename Fp6T::my_Fp2;
+
+    libsnark::Fp2_variable<Fp2T> _c0;
+    libsnark::Fp2_variable<Fp2T> _c1;
+    libsnark::Fp2_variable<Fp2T> _c2;
+
+    Fp6_3over2_variable(
+        libsnark::protoboard<FieldT> &pb, const std::string &annotation_prefix);
+
+    Fp6_3over2_variable(
+        libsnark::protoboard<FieldT> &pb,
+        const Fp6_3over2_variable<Fp6T> &v,
+        const std::string &annotation_prefix);
+
+    Fp6_3over2_variable(
+        libsnark::protoboard<FieldT> &pb,
+        const Fp6T &v,
+        const std::string &annotation_prefix);
+
+    Fp6_3over2_variable(
+        libsnark::protoboard<FieldT> &pb,
+        const libsnark::Fp2_variable<Fp2T> &c0,
+        const libsnark::Fp2_variable<Fp2T> &c1,
+        const libsnark::Fp2_variable<Fp2T> &c2,
+        const std::string &annotation_prefix);
+
+    Fp6_3over2_variable<Fp6T> operator*(const FieldT &);
+    Fp6_3over2_variable<Fp6T> operator+(const Fp6_3over2_variable<Fp6T> &);
+
+    void evaluate() const;
+    void generate_r1cs_witness(const Fp6T &v);
+    Fp6T get_element() const;
+};
+
+// Follows implementation in libff::Fp6_3over2_model, based on Devegili OhEig
+// Scott Dahab "Multiplication and Squaring on Pairing-Friendly Fields";
+// Section 4 (Karatsuba).
+//
+// For (a0, a1, a2) and (b0, b1, b2) elements in Fp6, the components of c=a*b
+// can be written:
+//   c = (a0*b0 + non_residue*((a1 + a2)(b1 + b2) - a1*b1 - a2*b2),
+//        (a0 + a1)(b0 + b1) - a0*b0 - a1*b1 + non_residue * a2*b2,
+//        (a0 + a2)(b0 + b2) - a0*b0 - a2*b2 + a1*b1)
+//
+// Here non-residue is the element in Fp2 in the function v^3 - non_residue
+// used to define Fp6.
+template<typename Fp6T>
+class Fp6_3over2_mul_gadget : public libsnark::gadget<typename Fp6T::my_Fp>
+{
+public:
+    using FieldT = typename Fp6T::my_Fp;
+    using Fp2T = typename Fp6T::my_Fp2;
+
+    Fp6_3over2_variable<Fp6T> _A;
+    Fp6_3over2_variable<Fp6T> _B;
+    Fp6_3over2_variable<Fp6T> _result;
+
+    // These conditions follow from the above expressions for c0, c1, c2:
+    //  a0*b0 = c0 - non_residue*((a1 + a2)(b1 + b2) - a1*b1 - a2*b2)
+    //  (a0 + a1)(b0 + b1) = c1 + a0*b0 + a1*b1 - non_residue * a2*b2
+    //  (a0 + a2)(b0 + b2) = c2 + a0*b0 + a2*b2 - a1*b1
+
+    libsnark::Fp2_mul_gadget<Fp2T> _a1b1;
+    libsnark::Fp2_mul_gadget<Fp2T> _a2b2;
+    libsnark::Fp2_mul_gadget<Fp2T> _a1a2_times_b1b2;
+    libsnark::Fp2_mul_gadget<Fp2T> _a0b0;
+    libsnark::Fp2_mul_gadget<Fp2T> _a0a1_times_b0b1;
+    libsnark::Fp2_mul_gadget<Fp2T> _a0a2_times_b0b2;
+
+    Fp6_3over2_mul_gadget(
+        libsnark::protoboard<FieldT> &pb,
+        const Fp6_3over2_variable<Fp6T> &A,
+        const Fp6_3over2_variable<Fp6T> &B,
+        const Fp6_3over2_variable<Fp6T> &result,
+        const std::string &annotation_prefix);
+
+    void generate_r1cs_constraints();
+    void generate_r1cs_witness();
+};
+
+} // namespace libzecale
+
+#include "libzecale/circuits/fields/fp6_3over2_gadgets.tcc"
+
+#endif // __ZECALE_CIRCUITS_FIELDS_FP6_3OVER2_GADGETS_HPP__

--- a/libzecale/circuits/fields/fp6_3over2_gadgets.tcc
+++ b/libzecale/circuits/fields/fp6_3over2_gadgets.tcc
@@ -65,7 +65,7 @@ Fp6_3over2_variable<Fp6T> Fp6_3over2_variable<Fp6T>::operator*(const FieldT &a)
         _c0 * a,
         _c1 * a,
         _c2 * a,
-        FMT(this->annotation_prefix, " * Fr"));
+        FMT(this->annotation_prefix, " *Fp"));
 }
 
 template<typename Fp6T>
@@ -77,7 +77,9 @@ Fp6_3over2_variable<Fp6T> Fp6_3over2_variable<Fp6T>::operator+(
         _c0 + a._c0,
         _c1 + a._c1,
         _c2 + a._c2,
-        FMT(this->annotation_prefix, " + a"));
+        FMT(this->annotation_prefix.c_str(),
+            " + %s",
+            a.annotation_prefix.c_str()));
 }
 
 template<typename Fp6T> void Fp6_3over2_variable<Fp6T>::evaluate() const
@@ -117,21 +119,21 @@ Fp6_3over2_mul_gadget<Fp6T>::Fp6_3over2_mul_gadget(
           pb,
           A._c1,
           B._c1,
-          libsnark::Fp2_variable<Fp2T>(pb, FMT(annotation_prefix, " a1b1")),
-          FMT(annotation_prefix, " a1*b1"))
+          libsnark::Fp2_variable<Fp2T>(pb, FMT(annotation_prefix, " a1*b1")),
+          FMT(annotation_prefix, " _a1b1"))
     , _a2b2(
           pb,
           A._c2,
           B._c2,
-          libsnark::Fp2_variable<Fp2T>(pb, FMT(annotation_prefix, " a2b2")),
-          FMT(annotation_prefix, " a2*b2"))
+          libsnark::Fp2_variable<Fp2T>(pb, FMT(annotation_prefix, " a2*b2")),
+          FMT(annotation_prefix, " _a2b2"))
     , _a1a2_times_b1b2(
           pb,
           A._c1 + A._c2,
           B._c1 + B._c2,
           libsnark::Fp2_variable<Fp2T>(
-              pb, FMT(annotation_prefix, " a1a2*b1b2")),
-          FMT(annotation_prefix, " (a1+a2)(b1+b2)"))
+              pb, FMT(annotation_prefix, " (a1+a2)*(b1+b2)")),
+          FMT(annotation_prefix, " _a1a2_times_b1b2"))
     // c0 = a0*b0 + non_residue*((a1 + a2)(b1 + b2) - a1*b1 - a2*b2)
     , _a0b0(
           pb,
@@ -140,7 +142,7 @@ Fp6_3over2_mul_gadget<Fp6T>::Fp6_3over2_mul_gadget(
           _result._c0 -
               (_a1a2_times_b1b2.result - _a1b1.result - _a2b2.result) *
                   Fp6T::non_residue,
-          FMT(annotation_prefix, " a0b0"))
+          FMT(annotation_prefix, " _a0b0"))
     // c1 = (a0 + a1)(b0 + b1) - a0*b0 - a1*b1 + non_residue * a2*b2
     , _a0a1_times_b0b1(
           pb,
@@ -148,14 +150,14 @@ Fp6_3over2_mul_gadget<Fp6T>::Fp6_3over2_mul_gadget(
           B._c0 + B._c1,
           _result._c1 + _a0b0.result + _a1b1.result -
               _a2b2.result * Fp6T::non_residue,
-          FMT(annotation_prefix, " (a0+a1)(b0+b1)"))
+          FMT(annotation_prefix, " _a0a1_times_b0b1"))
     // c2 = (a0 + a2)(b0 + b2) - a0*b0 - a2*b2 + a1*b1
     , _a0a2_times_b0b2(
           pb,
           A._c0 + A._c2,
           B._c0 + B._c2,
           _result._c2 + _a0b0.result + _a2b2.result - _a1b1.result,
-          FMT(annotation_prefix, " (a0+a2)(b0+b2)"))
+          FMT(annotation_prefix, " _a0a2_times_b0b2"))
 {
 }
 

--- a/libzecale/circuits/fields/fp6_3over2_gadgets.tcc
+++ b/libzecale/circuits/fields/fp6_3over2_gadgets.tcc
@@ -1,0 +1,215 @@
+// Copyright (c) 2015-2020 Clearmatics Technologies Ltd
+//
+// SPDX-License-Identifier: LGPL-3.0+
+
+#ifndef __ZECALE_CIRCUITS_FIELDS_FP6_3OVER2_GADGETS_TCC__
+#define __ZECALE_CIRCUITS_FIELDS_FP6_3OVER2_GADGETS_TCC__
+
+#include "libzecale/circuits/fields/fp6_3over2_gadgets.hpp"
+
+namespace libzecale
+{
+
+// Fp6_3over2_variable methods
+
+template<typename Fp6T>
+Fp6_3over2_variable<Fp6T>::Fp6_3over2_variable(
+    libsnark::protoboard<FieldT> &pb, const std::string &annotation_prefix)
+    : libsnark::gadget<FieldT>(pb, annotation_prefix)
+    , _c0(pb, FMT(annotation_prefix, " c0"))
+    , _c1(pb, FMT(annotation_prefix, " c1"))
+    , _c2(pb, FMT(annotation_prefix, " c2"))
+{
+}
+
+template<typename Fp6T>
+Fp6_3over2_variable<Fp6T>::Fp6_3over2_variable(
+    libsnark::protoboard<FieldT> &pb,
+    const Fp6_3over2_variable<Fp6T> &v,
+    const std::string &annotation_prefix)
+    : libsnark::gadget<FieldT>(pb, annotation_prefix)
+    , _c0(v._c0)
+    , _c1(v._c1)
+    , _c2(v._c2)
+{
+}
+
+template<typename Fp6T>
+Fp6_3over2_variable<Fp6T>::Fp6_3over2_variable(
+    libsnark::protoboard<FieldT> &pb,
+    const Fp6T &v,
+    const std::string &annotation_prefix)
+    : libsnark::gadget<FieldT>(pb, annotation_prefix)
+    , _c0(pb, v.c0, FMT(annotation_prefix, " c0"))
+    , _c1(pb, v.c1, FMT(annotation_prefix, " c1"))
+    , _c2(pb, v.c2, FMT(annotation_prefix, " c2"))
+{
+}
+
+template<typename Fp6T>
+Fp6_3over2_variable<Fp6T>::Fp6_3over2_variable(
+    libsnark::protoboard<FieldT> &pb,
+    const libsnark::Fp2_variable<Fp2T> &c0,
+    const libsnark::Fp2_variable<Fp2T> &c1,
+    const libsnark::Fp2_variable<Fp2T> &c2,
+    const std::string &annotation_prefix)
+    : libsnark::gadget<FieldT>(pb, annotation_prefix), _c0(c0), _c1(c1), _c2(c2)
+{
+}
+
+template<typename Fp6T>
+Fp6_3over2_variable<Fp6T> Fp6_3over2_variable<Fp6T>::operator*(const FieldT &a)
+{
+    return Fp6_3over2_variable<Fp6T>(
+        this->pb,
+        _c0 * a,
+        _c1 * a,
+        _c2 * a,
+        FMT(this->annotation_prefix, " * Fr"));
+}
+
+template<typename Fp6T>
+Fp6_3over2_variable<Fp6T> Fp6_3over2_variable<Fp6T>::operator+(
+    const Fp6_3over2_variable<Fp6T> &a)
+{
+    return Fp6_3over2_variable<Fp6T>(
+        this->pb,
+        _c0 + a._c0,
+        _c1 + a._c1,
+        _c2 + a._c2,
+        FMT(this->annotation_prefix, " + a"));
+}
+
+template<typename Fp6T> void Fp6_3over2_variable<Fp6T>::evaluate() const
+{
+    _c0.evaluate();
+    _c1.evaluate();
+    _c2.evaluate();
+}
+
+template<typename Fp6T>
+void Fp6_3over2_variable<Fp6T>::generate_r1cs_witness(const Fp6T &v)
+{
+    _c0.generate_r1cs_witness(v.c0);
+    _c1.generate_r1cs_witness(v.c1);
+    _c2.generate_r1cs_witness(v.c2);
+}
+
+template<typename Fp6T> Fp6T Fp6_3over2_variable<Fp6T>::get_element() const
+{
+    return Fp6T(_c0.get_element(), _c1.get_element(), _c2.get_element());
+}
+
+// Fp6_3over2_mul_gadget methods
+
+template<typename Fp6T>
+Fp6_3over2_mul_gadget<Fp6T>::Fp6_3over2_mul_gadget(
+    libsnark::protoboard<FieldT> &pb,
+    const Fp6_3over2_variable<Fp6T> &A,
+    const Fp6_3over2_variable<Fp6T> &B,
+    const Fp6_3over2_variable<Fp6T> &result,
+    const std::string &annotation_prefix)
+    : libsnark::gadget<FieldT>(pb, annotation_prefix)
+    , _A(A)
+    , _B(B)
+    , _result(result)
+    , _a1b1(
+          pb,
+          A._c1,
+          B._c1,
+          libsnark::Fp2_variable<Fp2T>(pb, FMT(annotation_prefix, " a1b1")),
+          FMT(annotation_prefix, " a1*b1"))
+    , _a2b2(
+          pb,
+          A._c2,
+          B._c2,
+          libsnark::Fp2_variable<Fp2T>(pb, FMT(annotation_prefix, " a2b2")),
+          FMT(annotation_prefix, " a2*b2"))
+    , _a1a2_times_b1b2(
+          pb,
+          A._c1 + A._c2,
+          B._c1 + B._c2,
+          libsnark::Fp2_variable<Fp2T>(
+              pb, FMT(annotation_prefix, " a1a2*b1b2")),
+          FMT(annotation_prefix, " (a1+a2)(b1+b2)"))
+    // c0 = a0*b0 + non_residue*((a1 + a2)(b1 + b2) - a1*b1 - a2*b2)
+    , _a0b0(
+          pb,
+          A._c0,
+          B._c0,
+          _result._c0 -
+              (_a1a2_times_b1b2.result - _a1b1.result - _a2b2.result) *
+                  Fp6T::non_residue,
+          FMT(annotation_prefix, " a0b0"))
+    // c1 = (a0 + a1)(b0 + b1) - a0*b0 - a1*b1 + non_residue * a2*b2
+    , _a0a1_times_b0b1(
+          pb,
+          A._c0 + A._c1,
+          B._c0 + B._c1,
+          _result._c1 + _a0b0.result + _a1b1.result -
+              _a2b2.result * Fp6T::non_residue,
+          FMT(annotation_prefix, " (a0+a1)(b0+b1)"))
+    // c2 = (a0 + a2)(b0 + b2) - a0*b0 - a2*b2 + a1*b1
+    , _a0a2_times_b0b2(
+          pb,
+          A._c0 + A._c2,
+          B._c0 + B._c2,
+          _result._c2 + _a0b0.result + _a2b2.result - _a1b1.result,
+          FMT(annotation_prefix, " (a0+a2)(b0+b2)"))
+{
+}
+
+template<typename Fp6T>
+void Fp6_3over2_mul_gadget<Fp6T>::generate_r1cs_constraints()
+{
+    _a1b1.generate_r1cs_constraints();
+    _a2b2.generate_r1cs_constraints();
+    _a1a2_times_b1b2.generate_r1cs_constraints();
+    _a0b0.generate_r1cs_constraints();
+    _a0a1_times_b0b1.generate_r1cs_constraints();
+    _a0a2_times_b0b2.generate_r1cs_constraints();
+}
+
+template<typename Fp6T>
+void Fp6_3over2_mul_gadget<Fp6T>::generate_r1cs_witness()
+{
+    const Fp2T a0 = _A._c0.get_element();
+    const Fp2T a1 = _A._c1.get_element();
+    const Fp2T a2 = _A._c2.get_element();
+    const Fp2T b0 = _B._c0.get_element();
+    const Fp2T b1 = _B._c1.get_element();
+    const Fp2T b2 = _B._c2.get_element();
+
+    // c0 = a0*b0 + non_residue*((a1 + a2)(b1 + b2) - a1*b1 - a2*b2)
+    _a1b1.generate_r1cs_witness();
+    const Fp2T a1b1 = _a1b1.result.get_element();
+    _a2b2.generate_r1cs_witness();
+    const Fp2T a2b2 = _a2b2.result.get_element();
+    _a1a2_times_b1b2.A.evaluate();
+    _a1a2_times_b1b2.B.evaluate();
+    _a1a2_times_b1b2.generate_r1cs_witness();
+    const Fp2T a1a2_times_b1b2 = _a1a2_times_b1b2.result.get_element();
+    const Fp2T a0b0 = a0 * b0;
+    _result._c0.generate_r1cs_witness(
+        a0b0 + Fp6T::mul_by_non_residue(a1a2_times_b1b2 - a1b1 - a2b2));
+    _a0b0.generate_r1cs_witness();
+
+    // c1 = (a0 + a1)(b0 + b1) - a0*b0 - a1*b1 + non_residue * a2*b2
+    const Fp2T a0a1_times_b0b1 = (a0 + a1) * (b0 + b1);
+    _result._c1.generate_r1cs_witness(
+        a0a1_times_b0b1 - a0b0 - a1b1 + Fp6T::mul_by_non_residue(a2b2));
+    _a0a1_times_b0b1.A.evaluate();
+    _a0a1_times_b0b1.B.evaluate();
+    _a0a1_times_b0b1.generate_r1cs_witness();
+
+    // c2 = (a0 + a2)(b0 + b2) - a0*b0 - a2*b2 + a1*b1
+    const Fp2T a0a2_times_b0b2 = (a0 + a2) * (b0 + b2);
+    _result._c2.generate_r1cs_witness(a0a2_times_b0b2 - a0b0 - a2b2 + a1b1);
+    _a0a2_times_b0b2.A.evaluate();
+    _a0a2_times_b0b2.B.evaluate();
+    _a0a2_times_b0b2.generate_r1cs_witness();
+}
+
+} // namespace libzecale
+
+#endif // __ZECALE_CIRCUITS_FIELDS_FP6_3OVER2_GADGETS_TCC__

--- a/libzecale/circuits/groth16_verifier/r1cs_gg_ppzksnark_verifier_gadget.tcc
+++ b/libzecale/circuits/groth16_verifier/r1cs_gg_ppzksnark_verifier_gadget.tcc
@@ -15,10 +15,12 @@ r1cs_gg_ppzksnark_proof_variable<ppT>::r1cs_gg_ppzksnark_proof_variable(
     libsnark::protoboard<FieldT> &pb, const std::string &annotation_prefix)
     : libsnark::gadget<FieldT>(pb, annotation_prefix)
 {
+#ifndef NDEBUG
     // g_A, g_C
     const size_t num_G1 = 2;
     // g_B
     const size_t num_G2 = 1;
+#endif
 
     g_A.reset(
         new libsnark::G1_variable<ppT>(pb, FMT(annotation_prefix, " g_A")));
@@ -104,10 +106,12 @@ r1cs_gg_ppzksnark_verification_key_variable<ppT>::
     , all_bits(all_bits)
     , input_size(input_size)
 {
+#ifndef NDEBUG
     // alpha_g1, ABC_g1
     const size_t num_G1 = 1 + (input_size + 1);
     // beta_g2, delta_g2
     const size_t num_G2 = 2;
+#endif
 
     assert(
         all_bits.size() ==

--- a/libzecale/circuits/pairing/bls12_377_pairing.hpp
+++ b/libzecale/circuits/pairing/bls12_377_pairing.hpp
@@ -73,17 +73,17 @@ public:
     // same variable as `check_A.result`. Do an optimization pass and remove
     // some of the redundancy.
 
-    // A = Rx * Ry / 2
+    // A = R.X * R.Y / 2
     libsnark::Fqe_variable<ppT> A;
-    libsnark::Fqe_mul_gadget<ppT> check_A; // Rx * Ry = 2_times_A
+    libsnark::Fqe_mul_gadget<ppT> check_A; // R.X * R.Y = 2_times_A
 
-    // B = Ry^2
+    // B = R.Y^2
     libsnark::Fqe_variable<ppT> B;
-    libsnark::Fqe_sqr_gadget<ppT> check_B; // Ry^2 == B
+    libsnark::Fqe_sqr_gadget<ppT> check_B; // R.Y^2 == B
 
-    // C = Rz^2
+    // C = R.Z^2
     libsnark::Fqe_variable<ppT> C;
-    libsnark::Fqe_sqr_gadget<ppT> check_C; // Rz^2 == C
+    libsnark::Fqe_sqr_gadget<ppT> check_C; // R.Z^2 == C
 
     // D = 3 * C
     // libsnark::Fqe_variable<ppT> D;
@@ -107,9 +107,9 @@ public:
     // I = E - B
     libsnark::Fqe_variable<ppT> I;
 
-    // J = Rx^2
+    // J = R.X^2
     libsnark::Fqe_variable<ppT> J;
-    libsnark::Fqe_sqr_gadget<ppT> check_J; // Rx^2 == J
+    libsnark::Fqe_sqr_gadget<ppT> check_J; // R.X^2 == J
 
     // E^2
     libsnark::Fqe_variable<ppT> E_squared;
@@ -122,15 +122,15 @@ public:
     // B - F
     libsnark::Fqe_variable<ppT> B_minus_F;
 
-    // outRx = A * (B - F)
+    // out_R.X = A * (B - F)
     libsnark::Fqe_mul_gadget<ppT> check_out_Rx;
 
-    // outRy = G^2 - 3 * E^2
+    // out_R.Y = G^2 - 3 * E^2
     // check: 1 * G_squared_minus_3_E_squared == outRy
     libsnark::Fqe_variable<ppT> G_squared_minus_3_E_squared;
     libsnark::Fqe_mul_by_lc_gadget<ppT> check_out_Ry;
 
-    // outRz = B * H
+    // out_R.Z = B * H
     libsnark::Fqe_mul_gadget<ppT> check_out_Rz;
 
     // ell_0 = xi * I
@@ -157,19 +157,19 @@ public:
     typedef libff::Fq<libsnark::other_curve<ppT>> FqT;
     typedef libff::Fqe<libsnark::other_curve<ppT>> FqeT;
 
-    libsnark::Fqe_variable<ppT> base_X;
-    libsnark::Fqe_variable<ppT> base_Y;
+    libsnark::Fqe_variable<ppT> Q_X;
+    libsnark::Fqe_variable<ppT> Q_Y;
     bls12_377_G2_proj<ppT> in_R;
 
-    // A = Qy * Rz;
+    // A = Q_Y * R.Z;
     libsnark::Fqe_variable<ppT> A;
     libsnark::Fqe_mul_gadget<ppT> check_A;
-    // B = Qx * Rz;
+    // B = Q_X * R.Z;
     libsnark::Fqe_variable<ppT> B;
     libsnark::Fqe_mul_gadget<ppT> check_B;
-    // theta = Ry - A;
+    // theta = R.Y - A;
     libsnark::Fqe_variable<ppT> theta;
-    // lambda = Rx - B;
+    // lambda = R.X - B;
     libsnark::Fqe_variable<ppT> lambda;
     // C = theta.squared();
     libsnark::Fqe_variable<ppT> C;
@@ -180,32 +180,32 @@ public:
     // E = lambda * D;
     libsnark::Fqe_variable<ppT> E;
     libsnark::Fqe_mul_gadget<ppT> check_E;
-    // F = Rz * C;
+    // F = R.Z * C;
     libsnark::Fqe_variable<ppT> F;
     libsnark::Fqe_mul_gadget<ppT> check_F;
-    // G = Rx * D;
+    // G = R.X * D;
     libsnark::Fqe_variable<ppT> G;
     libsnark::Fqe_mul_gadget<ppT> check_G;
     // H = E + F - (G + G);
     libsnark::Fqe_variable<ppT> H;
-    // I = Ry * E;
+    // I = R.Y * E;
     libsnark::Fqe_variable<ppT> I;
     libsnark::Fqe_mul_gadget<ppT> check_I;
-    // J = theta * Qx - lambda * Qy;
+    // J = theta * Q_X - lambda * Q_Y;
     libsnark::Fqe_variable<ppT> theta_times_Qx;
     libsnark::Fqe_mul_gadget<ppT> check_theta_times_Qx;
     libsnark::Fqe_variable<ppT> lambda_times_Qy;
     libsnark::Fqe_mul_gadget<ppT> check_lambda_times_Qy;
     libsnark::Fqe_variable<ppT> J;
 
-    // out_Rx = lambda * H;
+    // out_R.X = lambda * H;
     libsnark::Fqe_variable<ppT> out_Rx;
     libsnark::Fqe_mul_gadget<ppT> check_out_Rx;
-    // out_Ry = theta * (G - H) - I;
+    // out_R.Y = theta * (G - H) - I;
     libsnark::Fqe_variable<ppT> G_minus_H;
     libsnark::Fqe_variable<ppT> theta_times_G_minus_H;
     libsnark::Fqe_mul_gadget<ppT> check_theta_times_G_minus_H;
-    // out_Rz = Z1 * E;
+    // out_R.Z = Z1 * E;
     libsnark::Fqe_variable<ppT> out_Rz;
     libsnark::Fqe_mul_gadget<ppT> check_out_Rz;
 
@@ -218,8 +218,8 @@ public:
 
     bls12_377_ate_add_gadget(
         libsnark::protoboard<libff::Fr<ppT>> &pb,
-        const libsnark::Fqe_variable<ppT> &base_X,
-        const libsnark::Fqe_variable<ppT> &base_Y,
+        const libsnark::Fqe_variable<ppT> &Q_X,
+        const libsnark::Fqe_variable<ppT> &Q_Y,
         const bls12_377_G2_proj<ppT> &R,
         const std::string &annotation_prefix);
 

--- a/libzecale/circuits/pairing/bls12_377_pairing.hpp
+++ b/libzecale/circuits/pairing/bls12_377_pairing.hpp
@@ -23,34 +23,16 @@ public:
 
     bls12_377_G2_proj(
         libsnark::protoboard<libff::Fr<ppT>> &pb,
-        const std::string &annotation_prefix)
-        : X(pb, FMT(annotation_prefix, " X"))
-        , Y(pb, FMT(annotation_prefix, " Y"))
-        , Z(pb, FMT(annotation_prefix, " Z"))
-    {
-    }
+        const std::string &annotation_prefix);
 
     bls12_377_G2_proj(
         const libsnark::Fqe_variable<ppT> &X_var,
         const libsnark::Fqe_variable<ppT> &Y_var,
-        const libsnark::Fqe_variable<ppT> &Z_var)
-        : X(X_var), Y(Y_var), Z(Z_var)
-    {
-    }
+        const libsnark::Fqe_variable<ppT> &Z_var);
 
-    void evaluate() const
-    {
-        X.evaluate();
-        Y.evaluate();
-        Z.evaluate();
-    }
+    void evaluate() const;
 
-    void generate_r1cs_witness(const libff::bls12_377_G2 &element)
-    {
-        X.generate_r1cs_witness(element.X);
-        Y.generate_r1cs_witness(element.Y);
-        Z.generate_r1cs_witness(element.Z);
-    }
+    void generate_r1cs_witness(const libff::bls12_377_G2 &element);
 };
 
 /// Not a gadget - holds the variables for the Fq2 coefficients of the tangent
@@ -65,17 +47,9 @@ public:
     bls12_377_ate_ell_coeffs(
         const libsnark::Fqe_variable<ppT> &ell_0,
         const libsnark::Fqe_variable<ppT> &ell_vw,
-        const libsnark::Fqe_variable<ppT> &ell_vv)
-        : ell_0(ell_0), ell_vw(ell_vw), ell_vv(ell_vv)
-    {
-    }
+        const libsnark::Fqe_variable<ppT> &ell_vv);
 
-    void evaluate() const
-    {
-        ell_0.evaluate();
-        ell_vw.evaluate();
-        ell_vv.evaluate();
-    }
+    void evaluate() const;
 };
 
 /// Gadget that relates some "current" bls12_377_G2_proj value in_R with the
@@ -160,212 +134,13 @@ public:
     bls12_377_ate_dbl_gadget(
         libsnark::protoboard<FqT> &pb,
         const bls12_377_G2_proj<ppT> &R,
-        const std::string &annotation_prefix)
-        : libsnark::gadget<libff::Fr<ppT>>(pb, annotation_prefix)
-        , in_R(R)
-        , out_R(pb, " R")
+        const std::string &annotation_prefix);
 
-        // A = Rx * Ry / 2
-        , A(pb, FMT(annotation_prefix, " A"))
-        , check_A(
-              pb,
-              in_R.X,
-              in_R.Y,
-              A * FqT(2),
-              FMT(annotation_prefix, " check_A"))
-
-        // B = Ry^2
-        , B(pb, FMT(annotation_prefix, " B"))
-        , check_B(pb, in_R.Y, B, FMT(annotation_prefix, " check_B"))
-
-        // C = Rz^2
-        , C(pb, FMT(annotation_prefix, " C"))
-        , check_C(pb, in_R.Z, C, FMT(annotation_prefix, "check_C"))
-
-        // D = 3 * C
-        // , D(C * FqT(3))
-
-        // E = b' * D
-        , E((C * libff::Fr<ppT>(3)) * libff::bls12_377_twist_coeff_b)
-
-        // F = 3 * E
-        , F(E + E + E)
-
-        // G = (B + F) / 2  (added manually)
-        , G(pb, FMT(annotation_prefix, " G"))
-
-        // H = (Y + Z) ^ 2 - (B + C)
-        , H(pb, FMT(annotation_prefix, " H"))
-        // check: (Y + Z)^2 == H + B + C
-        , Y_plus_Z(in_R.Y + in_R.Z)
-        , H_plus_B_plus_C(H + B + C)
-        , check_H(
-              pb, Y_plus_Z, H_plus_B_plus_C, FMT(annotation_prefix, " check H"))
-
-        // I = (E - B)
-        , I(E + (B * -libff::Fr<ppT>::one()))
-
-        // J = Rx^2
-        , J(pb, FMT(annotation_prefix, " J"))
-        , check_J(pb, in_R.X, J, FMT(annotation_prefix, " check Rx^2"))
-
-        , E_squared(pb, FMT(annotation_prefix, " E^2"))
-        , check_E_squared(
-              pb, E, E_squared, FMT(annotation_prefix, " check E^2"))
-
-        , G_squared(pb, FMT(annotation_prefix, " G^2"))
-        , check_G_squared(
-              pb, G, G_squared, FMT(annotation_prefix, " check G^2"))
-
-        , B_minus_F(B + (F * -libff::Fr<ppT>::one()))
-
-        // outRx = A * (B-F)
-        , check_out_Rx(
-              pb, A, B_minus_F, out_R.X, FMT(annotation_prefix, " check outRx"))
-
-        // outRy = G^2 - 3E^2
-        // check: outRy + E^2 + E^2 + E^2 == G^2  (TODO: not required)
-        , G_squared_minus_3_E_squared(
-              G_squared + (E_squared * -libff::Fr<ppT>("3")))
-        , check_out_Ry(
-              pb,
-              G_squared_minus_3_E_squared,
-              {0}, // one
-              out_R.Y,
-              FMT(annotation_prefix, " check outRy"))
-
-        , check_out_Rz(
-              pb, B, H, out_R.Z, FMT(annotation_prefix, " check outRz"))
-
-        // ell_0 = xi * I
-        // ell_vw = -H
-        // ell_vv = 3 * J
-        , out_coeffs(
-              I * libff::bls12_377_twist,
-              H * -libff::Fr<ppT>(1),
-              J * libff::Fr<ppT>(3))
-    {
-    }
-
-    void generate_r1cs_constraints()
-    {
-        check_A.generate_r1cs_constraints();
-        check_B.generate_r1cs_constraints();
-        check_C.generate_r1cs_constraints();
-
-        // D = 3 * C
-        // E = b' * D
-        //   = b' * (C + C + C)  (2 constraints for mul by Fq2 constant)
-        // F = 3 * E
-
-        // G = (B + F) / 2 checked as 2 * G == B + F
-        this->pb.add_r1cs_constraint(
-            {1, 2 * G.c0, B.c0 + F.c0},
-            FMT(this->annotation_prefix, " check G.c0"));
-        this->pb.add_r1cs_constraint(
-            {1, 2 * G.c1, B.c1 + F.c1},
-            FMT(this->annotation_prefix, " check G.c1"));
-
-        // H = (Y + Z) ^ 2 - (B + C)
-        check_H.generate_r1cs_constraints();
-
-        // I = E - B
-        // J = Rx^2
-        check_J.generate_r1cs_constraints();
-
-        // E_squared
-        check_E_squared.generate_r1cs_constraints();
-
-        // G_squared
-        check_G_squared.generate_r1cs_constraints();
-
-        // B_minus_F
-        // check_B_minus_F.generate_r1cs_constraints();
-
-        // outRx = A * (B - F)
-        check_out_Rx.generate_r1cs_constraints();
-
-        // outRy = G^2 - 3 * E^2
-        check_out_Ry.generate_r1cs_constraints();
-
-        // outRz = B * H
-        check_out_Rz.generate_r1cs_constraints();
-
-        // There are just linear combinations, so no need for constraints:
-        // ell_0 = xi * I
-        // ell_vw = -H
-        // ell_vv = 3 * J
-    }
+    void generate_r1cs_constraints();
 
     // R should already be assigned. Computes all internal values and
     // outResult.
-    void generate_r1cs_witness(const libff::Fr<ppT> &two_inv)
-    {
-        const FqeT Rx = in_R.X.get_element();
-        const FqeT Ry = in_R.Y.get_element();
-        const FqeT Rz = in_R.Z.get_element();
-
-        // A = Rx * Ry / 2
-        A.generate_r1cs_witness(two_inv * Rx * Ry);
-        check_A.generate_r1cs_witness();
-
-        // B = Ry^2
-        check_B.generate_r1cs_witness();
-
-        // C = Rz^2
-        check_C.generate_r1cs_witness();
-
-        // D = 3 * C
-        // D.generate_r1cs_witness();
-
-        // E = b' * D
-        E.evaluate();
-        assert(
-            E.get_element() == libff::Fr<ppT>(3) * C.get_element() *
-                                   libff::bls12_377_twist_coeff_b);
-
-        // F = 3 * E (linear comb)
-        F.evaluate();
-        assert(F.get_element() == libff::Fr<ppT>(3) * E.get_element());
-
-        // G = (B + F) / 2
-        G.generate_r1cs_witness(two_inv * (B.get_element() + F.get_element()));
-
-        // H = (Y + Z) ^ 2 - (B + C)
-        const FqeT Y_plus_Z_squared = (Ry + Rz).squared();
-        H.generate_r1cs_witness(
-            Y_plus_Z_squared - B.get_element() - C.get_element());
-        check_H.generate_r1cs_witness();
-
-        // I = E - B
-        I.evaluate();
-
-        // J = Rx^2
-        check_J.generate_r1cs_witness();
-
-        // E^2
-        check_E_squared.generate_r1cs_witness();
-
-        // G^2
-        check_G_squared.generate_r1cs_witness();
-
-        // out_Rx = A * (B - F) (assigned by check_outRx)
-        B_minus_F.evaluate();
-        assert(B.get_element() - F.get_element() == B_minus_F.get_element());
-        check_out_Rx.generate_r1cs_witness();
-
-        // out_Ry = G^2 - 3 * E^2
-        G_squared_minus_3_E_squared.evaluate();
-        check_out_Ry.generate_r1cs_witness();
-
-        // out_Rz = B * H (assigned by check_outRz)
-        check_out_Rz.generate_r1cs_witness();
-
-        // ell_0 = xi * I (assigned by check_ell_0)
-        // ell_vw = -H
-        // ell_vv = 3 * J
-        out_coeffs.evaluate();
-    }
+    void generate_r1cs_witness(const libff::Fr<ppT> &two_inv);
 };
 
 template<typename ppT>
@@ -439,173 +214,15 @@ public:
         const libsnark::Fqe_variable<ppT> &base_X,
         const libsnark::Fqe_variable<ppT> &base_Y,
         const bls12_377_G2_proj<ppT> &R,
-        const std::string &annotation_prefix)
-        : libsnark::gadget<libff::Fr<ppT>>(pb, annotation_prefix)
-        , base_X(base_X)
-        , base_Y(base_Y)
-        , in_R(R)
+        const std::string &annotation_prefix);
 
-        // A = Qy * Rz
-        , A(pb, FMT(annotation_prefix, " A"))
-        , check_A(pb, base_Y, in_R.Z, A, FMT(annotation_prefix, " check A"))
-        // B = Qx * Rz;
-        , B(pb, FMT(annotation_prefix, " B"))
-        , check_B(pb, base_X, in_R.Z, B, FMT(annotation_prefix, " check B"))
-        // theta = Ry - A;
-        , theta(in_R.Y + (A * -libff::Fr<ppT>::one()))
-        // lambda = Rx - B;
-        , lambda(in_R.X + (B * -libff::Fr<ppT>::one()))
-        // C = theta.squared();
-        , C(pb, FMT(annotation_prefix, " C"))
-        , check_C(pb, theta, C, FMT(annotation_prefix, " check C"))
-        // D = lambda.squared();
-        , D(pb, FMT(annotation_prefix, " D"))
-        , check_D(pb, lambda, D, FMT(annotation_prefix, " check D"))
-        // E = lambda * D;
-        , E(pb, FMT(annotation_prefix, " E"))
-        , check_E(pb, lambda, D, E, FMT(annotation_prefix, " check E"))
-        // F = Rz * C;
-        , F(pb, FMT(annotation_prefix, " F"))
-        , check_F(pb, in_R.Z, C, F, FMT(annotation_prefix, " check F"))
-        // G = Rx * D;
-        , G(pb, FMT(annotation_prefix, " G"))
-        , check_G(pb, in_R.X, D, G, FMT(annotation_prefix, " check G"))
-        // H = E + F - (G + G);
-        , H(E + F + (G * -libff::Fr<ppT>(2)))
-        // I = Ry * E;
-        , I(pb, FMT(annotation_prefix, " I"))
-        , check_I(pb, in_R.Y, E, I, FMT(annotation_prefix, " check I"))
-        // J = theta * Qx - lambda * Qy;
-        , theta_times_Qx(pb, FMT(annotation_prefix, " theta_times_Rx"))
-        , check_theta_times_Qx(
-              pb,
-              theta,
-              base_X,
-              theta_times_Qx,
-              FMT(annotation_prefix, " check_theta_times_Qx"))
-        , lambda_times_Qy(pb, FMT(annotation_prefix, " lambda_times_Qy"))
-        , check_lambda_times_Qy(
-              pb,
-              lambda,
-              base_Y,
-              lambda_times_Qy,
-              FMT(annotation_prefix, " check_lambda_times_Qy"))
-        , J(theta_times_Qx + (lambda_times_Qy * -libff::Fr<ppT>::one()))
+    void generate_r1cs_constraints();
 
-        // out_Rx = lambda * H;
-        , out_Rx(pb, FMT(annotation_prefix, " out_Rx"))
-        , check_out_Rx(
-              pb, lambda, H, out_Rx, FMT(annotation_prefix, " check out_Rx"))
-        // out_Ry = theta * (G - H) - I;
-        , G_minus_H(G + (H * -libff::Fr<ppT>::one()))
-        , theta_times_G_minus_H(
-              pb, FMT(annotation_prefix, " theta_times_G_minus_H"))
-        , check_theta_times_G_minus_H(
-              pb,
-              theta,
-              G_minus_H,
-              theta_times_G_minus_H,
-              FMT(annotation_prefix, " check_theta_times_G_minus_H"))
-        // out_Rz = Rza * E;
-        , out_Rz(pb, FMT(annotation_prefix, " out_Rz"))
-        , check_out_Rz(
-              pb, in_R.Z, E, out_Rz, FMT(annotation_prefix, " check Rz"))
-
-        , out_R(
-              out_Rx,
-              theta_times_G_minus_H + (I * -libff::Fr<ppT>::one()),
-              out_Rz)
-
-        // out_coeffs.ell_0 = xi * J;
-        // out_coeffs.ell_vw = lambda;
-        // out_coeffs.ell_vv = -theta;
-        , out_coeffs(
-              J * libff::bls12_377_twist,
-              lambda,
-              theta * -libff::Fr<ppT>::one())
-    {
-    }
-
-    void generate_r1cs_constraints()
-    {
-        // A = Ry * Rz  (A assigned by check_A)
-        check_A.generate_r1cs_constraints();
-        // B = Rx * Rz  (B assigned by check_B)
-        check_B.generate_r1cs_constraints();
-        // theta = Ry - A;
-        // lambda = Rx - B;
-        // C = theta.squared()  (C assigned by check_C)
-        check_C.generate_r1cs_constraints();
-        // D = lambda.squared();
-        check_D.generate_r1cs_constraints();
-        // E = lambda * D;
-        check_E.generate_r1cs_constraints();
-        // F = Rz * C;
-        check_F.generate_r1cs_constraints();
-        // G = Rx * D;
-        check_G.generate_r1cs_constraints();
-        // H = E + F - (G + G);
-        // I = Ry * E;
-        check_I.generate_r1cs_constraints();
-        // J = theta * Qx - lambda * Qy;
-        check_theta_times_Qx.generate_r1cs_constraints();
-        check_lambda_times_Qy.generate_r1cs_constraints();
-        // out_Rx = lambda * H;
-        check_out_Rx.generate_r1cs_constraints();
-        // out_Ry = theta * (G - H) - I;
-        check_theta_times_G_minus_H.generate_r1cs_constraints();
-        // out_Rz = Z1 * E;
-        check_out_Rz.generate_r1cs_constraints();
-        // out_coeffs.ell_0 = xi * J;
-        // out_coeffs.ell_VV = -theta;
-        // out_coeffs.ell_VW = lambda;
-    }
-
-    void generate_r1cs_witness()
-    {
-        // A = Ry * Rz  (A assigned by check_A)
-        check_A.generate_r1cs_witness();
-        // B = Rx * Rz  (B assigned by check_B)
-        check_B.generate_r1cs_witness();
-        // theta = Ry - A;
-        theta.evaluate();
-        // lambda = Rx - B;
-        lambda.evaluate();
-        // C = theta.squared()  (C assigned by check_C)
-        check_C.generate_r1cs_witness();
-        // D = lambda.squared()  (D assigned by check_D)
-        check_D.generate_r1cs_witness();
-        // E = lambda * D  (E assigned by check_E)
-        check_E.generate_r1cs_witness();
-        // F = Rz * C  (F assigned by check_F)
-        check_F.generate_r1cs_witness();
-        // G = Rx * D;
-        check_G.generate_r1cs_witness();
-        // H = E + F - (G + G);
-        H.evaluate();
-        // I = Ry * E  (I assigned by check_I)
-        check_I.generate_r1cs_witness();
-        // J = theta * Qx - lambda * Qy;
-        check_theta_times_Qx.generate_r1cs_witness();
-        check_lambda_times_Qy.generate_r1cs_witness();
-        J.evaluate();
-
-        // out_Rx = lambda * H (assigned by check_out_Rx)
-        check_out_Rx.generate_r1cs_witness();
-        // out_Ry = theta * (G - H) - I;
-        G_minus_H.evaluate();
-        check_theta_times_G_minus_H.generate_r1cs_witness();
-        // out_Rz = Z1 * E (assigned by check_out_Rz)
-        check_out_Rz.generate_r1cs_witness();
-        out_R.evaluate();
-
-        // out_coeffs.ell_0 = xi * J;
-        // out_coeffs.ell_vw = lambda;
-        // out_coeffs.ell_vv = -theta;
-        out_coeffs.evaluate();
-    }
+    void generate_r1cs_witness();
 };
 
 } // namespace libzecale
+
+#include "libzecale/circuits/pairing/bls12_377_pairing.tcc"
 
 #endif // __ZECALE_CIRCUITS_PAIRING_BLS12_377_PAIRING_HPP__

--- a/libzecale/circuits/pairing/bls12_377_pairing.hpp
+++ b/libzecale/circuits/pairing/bls12_377_pairing.hpp
@@ -14,8 +14,7 @@ namespace libzecale
 
 /// Holds an element of G2 in homogeneous projective form. Used for
 /// intermediate values of R in the miller loop.
-template<typename ppT>
-class bls12_377_G2_proj : libsnark::gadget<libff::Fr<ppT>>
+template<typename ppT> class bls12_377_G2_proj
 {
 public:
     libsnark::Fqe_variable<ppT> X;
@@ -25,8 +24,7 @@ public:
     bls12_377_G2_proj(
         libsnark::protoboard<libff::Fr<ppT>> &pb,
         const std::string &annotation_prefix)
-        : libsnark::gadget<libff::Fr<ppT>>(pb, annotation_prefix)
-        , X(pb, FMT(annotation_prefix, " X"))
+        : X(pb, FMT(annotation_prefix, " X"))
         , Y(pb, FMT(annotation_prefix, " Y"))
         , Z(pb, FMT(annotation_prefix, " Z"))
     {
@@ -45,9 +43,9 @@ public:
 template<typename ppT> class bls12_377_ate_ell_coeffs
 {
 public:
-    libsnark::Fqe_variable<ppT> ell_0;
-    libsnark::Fqe_variable<ppT> ell_vw;
-    libsnark::Fqe_variable<ppT> ell_vv;
+    const libsnark::Fqe_variable<ppT> ell_0;
+    const libsnark::Fqe_variable<ppT> ell_vw;
+    const libsnark::Fqe_variable<ppT> ell_vv;
 
     bls12_377_ate_ell_coeffs(
         const libsnark::Fqe_variable<ppT> &ell_0,
@@ -55,6 +53,13 @@ public:
         const libsnark::Fqe_variable<ppT> &ell_vv)
         : ell_0(ell_0), ell_vw(ell_vw), ell_vv(ell_vv)
     {
+    }
+
+    void evaluate() const
+    {
+        ell_0.evaluate();
+        ell_vw.evaluate();
+        ell_vv.evaluate();
     }
 };
 
@@ -342,11 +347,9 @@ public:
         check_out_Rz.generate_r1cs_witness();
 
         // ell_0 = xi * I (assigned by check_ell_0)
-        out_coeffs.ell_0.evaluate();
         // ell_vw = -H
-        out_coeffs.ell_vw.evaluate();
         // ell_vv = 3 * J
-        out_coeffs.ell_vv.evaluate();
+        out_coeffs.evaluate();
     }
 };
 

--- a/libzecale/circuits/pairing/bls12_377_pairing.hpp
+++ b/libzecale/circuits/pairing/bls12_377_pairing.hpp
@@ -68,6 +68,11 @@ public:
     bls12_377_G2_proj<ppT> in_R;
     bls12_377_G2_proj<ppT> out_R;
 
+    // TODO: Many of these intermediate Fqe_variables are only for clarity and
+    // replicate the references held by other gadgets (e.g. `A` refers to the
+    // same variable as `check_A.result`. Do an optimization pass and remove
+    // some of the redundancy.
+
     // A = Rx * Ry / 2
     libsnark::Fqe_variable<ppT> A;
     libsnark::Fqe_mul_gadget<ppT> check_A; // Rx * Ry = 2_times_A

--- a/libzecale/circuits/pairing/bls12_377_pairing.hpp
+++ b/libzecale/circuits/pairing/bls12_377_pairing.hpp
@@ -221,6 +221,34 @@ public:
     void generate_r1cs_witness();
 };
 
+/// Holds the relationship between an (affine) pairing parameter Q in G2, and
+/// the precomputed double and add gadgets.
+template<typename ppT>
+class bls12_377_ate_precompute_gadget : libsnark::gadget<libff::Fr<ppT>>
+{
+public:
+    using FqeT = libff::Fqe<libsnark::other_curve<ppT>>;
+
+    libsnark::Fqe_variable<ppT> _Qx;
+    libsnark::Fqe_variable<ppT> _Qy;
+    bls12_377_G2_proj<ppT> _R0;
+
+    std::vector<std::shared_ptr<bls12_377_ate_dbl_gadget<ppT>>> _ate_dbls;
+    std::vector<std::shared_ptr<bls12_377_ate_add_gadget<ppT>>> _ate_adds;
+
+    bls12_377_ate_precompute_gadget(
+        libsnark::protoboard<libff::Fr<ppT>> &pb,
+        const libsnark::Fqe_variable<ppT> &Qx,
+        const libsnark::Fqe_variable<ppT> &Qy,
+        const std::string &annotation_prefix);
+
+    void generate_r1cs_constraints();
+
+    /// The Qx and Qy variables passed to the constructor must have been
+    /// assigned
+    void generate_r1cs_witness();
+};
+
 } // namespace libzecale
 
 #include "libzecale/circuits/pairing/bls12_377_pairing.tcc"

--- a/libzecale/circuits/pairing/bls12_377_pairing.hpp
+++ b/libzecale/circuits/pairing/bls12_377_pairing.hpp
@@ -1,0 +1,355 @@
+// Copyright (c) 2015-2020 Clearmatics Technologies Ltd
+//
+// SPDX-License-Identifier: LGPL-3.0+
+
+#ifndef __ZECALE_CIRCUITS_PAIRING_BLS12_377_PAIRING_HPP__
+#define __ZECALE_CIRCUITS_PAIRING_BLS12_377_PAIRING_HPP__
+
+#include <libff/algebra/curves/bls12_377/bls12_377_pp.hpp>
+#include <libsnark/gadgetlib1/gadgets/fields/fp2_gadgets.hpp>
+#include <libsnark/gadgetlib1/gadgets/pairing/pairing_params.hpp>
+
+namespace libzecale
+{
+
+/// Holds an element of G2 in homogeneous projective form. Used for
+/// intermediate values of R in the miller loop.
+template<typename ppT>
+class bls12_377_G2_proj : libsnark::gadget<libff::Fr<ppT>>
+{
+public:
+    libsnark::Fqe_variable<ppT> X;
+    libsnark::Fqe_variable<ppT> Y;
+    libsnark::Fqe_variable<ppT> Z;
+
+    bls12_377_G2_proj(
+        libsnark::protoboard<libff::Fr<ppT>> &pb,
+        const std::string &annotation_prefix)
+        : libsnark::gadget<libff::Fr<ppT>>(pb, annotation_prefix)
+        , X(pb, FMT(annotation_prefix, " X"))
+        , Y(pb, FMT(annotation_prefix, " Y"))
+        , Z(pb, FMT(annotation_prefix, " Z"))
+    {
+    }
+
+    void generate_r1cs_witness(const libff::bls12_377_G2 &element)
+    {
+        X.generate_r1cs_witness(element.X);
+        Y.generate_r1cs_witness(element.Y);
+        Z.generate_r1cs_witness(element.Z);
+    }
+};
+
+/// Not a gadget - holds the variables for the Fq2 coefficients of the tangent
+/// line at some R, used during the doubling step.
+template<typename ppT> class bls12_377_ate_ell_coeffs
+{
+public:
+    libsnark::Fqe_variable<ppT> ell_0;
+    libsnark::Fqe_variable<ppT> ell_vw;
+    libsnark::Fqe_variable<ppT> ell_vv;
+
+    bls12_377_ate_ell_coeffs(
+        const libsnark::Fqe_variable<ppT> &ell_0,
+        const libsnark::Fqe_variable<ppT> &ell_vw,
+        const libsnark::Fqe_variable<ppT> &ell_vv)
+        : ell_0(ell_0), ell_vw(ell_vw), ell_vv(ell_vv)
+    {
+    }
+};
+
+/// Gadget that relates some "current" bls12_377_G2_proj value in_R with the
+/// result of the doubling step, that is some bls12_377_G2_proj out_R and the
+/// bls12_377_ate_ell_coeffs holding the coefficients of the tangent at in_R.
+/// Note that the output variables are allocated by this gadget.
+template<typename ppT>
+class bls12_377_ate_dbl_gadget : libsnark::gadget<libff::Fr<ppT>>
+{
+public:
+    typedef libff::Fq<libsnark::other_curve<ppT>> FqT;
+    typedef libff::Fqe<libsnark::other_curve<ppT>> FqeT;
+
+    bls12_377_G2_proj<ppT> in_R;
+    bls12_377_G2_proj<ppT> out_R;
+
+    // A = Rx * Ry / 2
+    libsnark::Fqe_variable<ppT> A;
+    libsnark::Fqe_mul_gadget<ppT> check_A; // Rx * Ry = 2_times_A
+
+    // B = Ry^2
+    libsnark::Fqe_variable<ppT> B;
+    libsnark::Fqe_sqr_gadget<ppT> check_B; // Ry^2 == B
+
+    // C = Rz^2
+    libsnark::Fqe_variable<ppT> C;
+    libsnark::Fqe_sqr_gadget<ppT> check_C; // Rz^2 == C
+
+    // D = 3 * C
+    // libsnark::Fqe_variable<ppT> D;
+
+    // E = b' * D
+    libsnark::Fqe_variable<ppT> E;
+
+    // F = 3 * E
+    libsnark::Fqe_variable<ppT> F;
+
+    // G = (B + F) / 2
+    libsnark::Fqe_variable<ppT> G;
+    // libsnark::Fqe_mul_by_lc_gadget<ppT> check_G; // 2 * G == B + F
+
+    // H = (Y + 2) ^ 2 - (B + C)
+    libsnark::Fqe_variable<ppT> H;
+    libsnark::Fqe_variable<ppT> Y_plus_Z;
+    libsnark::Fqe_variable<ppT> H_plus_B_plus_C;
+    libsnark::Fqe_sqr_gadget<ppT> check_H; // Y_plus_Z^2 == H + B + C
+
+    // I = E - B
+    libsnark::Fqe_variable<ppT> I;
+
+    // J = Rx^2
+    libsnark::Fqe_variable<ppT> J;
+    libsnark::Fqe_sqr_gadget<ppT> check_J; // Rx^2 == J
+
+    // E^2
+    libsnark::Fqe_variable<ppT> E_squared;
+    libsnark::Fqe_sqr_gadget<ppT> check_E_squared;
+
+    // G^2
+    libsnark::Fqe_variable<ppT> G_squared;
+    libsnark::Fqe_sqr_gadget<ppT> check_G_squared;
+
+    // B - F
+    libsnark::Fqe_variable<ppT> B_minus_F;
+
+    // outRx = A * (B - F)
+    libsnark::Fqe_mul_gadget<ppT> check_out_Rx;
+
+    // outRy = G^2 - 3 * E^2
+    // check: 1 * G_squared_minus_3_E_squared == outRy
+    libsnark::Fqe_variable<ppT> G_squared_minus_3_E_squared;
+    libsnark::Fqe_mul_by_lc_gadget<ppT> check_out_Ry;
+
+    // outRz = B * H
+    libsnark::Fqe_mul_gadget<ppT> check_out_Rz;
+
+    // ell_0 = xi * I
+    // ell_vw = -H
+    // ell_vv = 3 * J
+    bls12_377_ate_ell_coeffs<ppT> out_coeffs;
+
+    bls12_377_ate_dbl_gadget(
+        libsnark::protoboard<FqT> &pb,
+        const bls12_377_G2_proj<ppT> &R,
+        const std::string &annotation_prefix)
+        : libsnark::gadget<libff::Fr<ppT>>(pb, annotation_prefix)
+        , in_R(R)
+        , out_R(pb, " R")
+
+        // A = Rx * Ry / 2
+        , A(pb, FMT(annotation_prefix, " A"))
+        , check_A(
+              pb,
+              in_R.X,
+              in_R.Y,
+              A * FqT(2),
+              FMT(annotation_prefix, " check_A"))
+
+        // B = Ry^2
+        , B(pb, FMT(annotation_prefix, " B"))
+        , check_B(pb, in_R.Y, B, FMT(annotation_prefix, " check_B"))
+
+        // C = Rz^2
+        , C(pb, FMT(annotation_prefix, " C"))
+        , check_C(pb, in_R.Z, C, FMT(annotation_prefix, "check_C"))
+
+        // D = 3 * C
+        // , D(C * FqT(3))
+
+        // E = b' * D
+        , E((C * libff::Fr<ppT>(3)) * libff::bls12_377_twist_coeff_b)
+
+        // F = 3 * E
+        , F(E + E + E)
+
+        // G = (B + F) / 2  (added manually)
+        , G(pb, FMT(annotation_prefix, " G"))
+
+        // H = (Y + Z) ^ 2 - (B + C)
+        , H(pb, FMT(annotation_prefix, " H"))
+        // check: (Y + Z)^2 == H + B + C
+        , Y_plus_Z(in_R.Y + in_R.Z)
+        , H_plus_B_plus_C(H + B + C)
+        , check_H(
+              pb, Y_plus_Z, H_plus_B_plus_C, FMT(annotation_prefix, " check H"))
+
+        // I = (E - B)
+        , I(E + (B * -libff::Fr<ppT>::one()))
+
+        // J = Rx^2
+        , J(pb, FMT(annotation_prefix, " J"))
+        , check_J(pb, in_R.X, J, FMT(annotation_prefix, " check Rx^2"))
+
+        , E_squared(pb, FMT(annotation_prefix, " E^2"))
+        , check_E_squared(
+              pb, E, E_squared, FMT(annotation_prefix, " check E^2"))
+
+        , G_squared(pb, FMT(annotation_prefix, " G^2"))
+        , check_G_squared(
+              pb, G, G_squared, FMT(annotation_prefix, " check G^2"))
+
+        , B_minus_F(B + (F * -libff::Fr<ppT>::one()))
+
+        // outRx = A * (B-F)
+        , check_out_Rx(
+              pb, A, B_minus_F, out_R.X, FMT(annotation_prefix, " check outRx"))
+
+        // outRy = G^2 - 3E^2
+        // check: outRy + E^2 + E^2 + E^2 == G^2  (TODO: not required)
+        , G_squared_minus_3_E_squared(
+              G_squared + (E_squared * -libff::Fr<ppT>("3")))
+        , check_out_Ry(
+              pb,
+              G_squared_minus_3_E_squared,
+              {0}, // one
+              out_R.Y,
+              FMT(annotation_prefix, " check outRy"))
+
+        , check_out_Rz(
+              pb, B, H, out_R.Z, FMT(annotation_prefix, " check outRz"))
+
+        // ell_0 = xi * I
+        // ell_vw = -H
+        // ell_vv = 3 * J
+        , out_coeffs(
+              I * libff::bls12_377_twist,
+              H * -libff::Fr<ppT>(1),
+              J * libff::Fr<ppT>(3))
+    {
+    }
+
+    void generate_r1cs_constraints()
+    {
+        check_A.generate_r1cs_constraints();
+        check_B.generate_r1cs_constraints();
+        check_C.generate_r1cs_constraints();
+
+        // D = 3 * C
+        // E = b' * D
+        //   = b' * (C + C + C)  (2 constraints for mul by Fq2 constant)
+        // F = 3 * E
+
+        // G = (B + F) / 2 checked as 2 * G == B + F
+        this->pb.add_r1cs_constraint(
+            {1, 2 * G.c0, B.c0 + F.c0},
+            FMT(this->annotation_prefix, " check G.c0"));
+        this->pb.add_r1cs_constraint(
+            {1, 2 * G.c1, B.c1 + F.c1},
+            FMT(this->annotation_prefix, " check G.c1"));
+
+        // H = (Y + Z) ^ 2 - (B + C)
+        check_H.generate_r1cs_constraints();
+
+        // I = E - B
+        // J = Rx^2
+        check_J.generate_r1cs_constraints();
+
+        // E_squared
+        check_E_squared.generate_r1cs_constraints();
+
+        // G_squared
+        check_G_squared.generate_r1cs_constraints();
+
+        // B_minus_F
+        // check_B_minus_F.generate_r1cs_constraints();
+
+        // outRx = A * (B - F)
+        check_out_Rx.generate_r1cs_constraints();
+
+        // outRy = G^2 - 3 * E^2
+        check_out_Ry.generate_r1cs_constraints();
+
+        // outRz = B * H
+        check_out_Rz.generate_r1cs_constraints();
+
+        // There are just linear combinations, so no need for constraints:
+        // ell_0 = xi * I
+        // ell_vw = -H
+        // ell_vv = 3 * J
+    }
+
+    // R should already be assigned. Computes all internal values and
+    // outResult.
+    void generate_r1cs_witness(const libff::Fr<ppT> &two_inv)
+    {
+        const FqeT Rx = in_R.X.get_element();
+        const FqeT Ry = in_R.Y.get_element();
+        const FqeT Rz = in_R.Z.get_element();
+
+        // A = Rx * Ry / 2
+        A.generate_r1cs_witness(two_inv * Rx * Ry);
+        check_A.generate_r1cs_witness();
+
+        // B = Ry^2
+        check_B.generate_r1cs_witness();
+
+        // C = Rz^2
+        check_C.generate_r1cs_witness();
+
+        // D = 3 * C
+        // D.generate_r1cs_witness();
+
+        // E = b' * D
+        E.evaluate();
+        assert(
+            E.get_element() == libff::Fr<ppT>(3) * C.get_element() *
+                                   libff::bls12_377_twist_coeff_b);
+
+        // F = 3 * E (linear comb)
+        F.evaluate();
+        assert(F.get_element() == libff::Fr<ppT>(3) * E.get_element());
+
+        // G = (B + F) / 2
+        G.generate_r1cs_witness(two_inv * (B.get_element() + F.get_element()));
+
+        // H = (Y + Z) ^ 2 - (B + C)
+        const FqeT Y_plus_Z_squared = (Ry + Rz).squared();
+        H.generate_r1cs_witness(
+            Y_plus_Z_squared - B.get_element() - C.get_element());
+        check_H.generate_r1cs_witness();
+
+        // I = E - B
+        I.evaluate();
+
+        // J = Rx^2
+        check_J.generate_r1cs_witness();
+
+        // E^2
+        check_E_squared.generate_r1cs_witness();
+
+        // G^2
+        check_G_squared.generate_r1cs_witness();
+
+        // out_Rx = A * (B - F) (assigned by check_outRx)
+        B_minus_F.evaluate();
+        assert(B.get_element() - F.get_element() == B_minus_F.get_element());
+        check_out_Rx.generate_r1cs_witness();
+
+        // out_Ry = G^2 - 3 * E^2
+        G_squared_minus_3_E_squared.evaluate();
+        check_out_Ry.generate_r1cs_witness();
+
+        // out_Rz = B * H (assigned by check_outRz)
+        check_out_Rz.generate_r1cs_witness();
+
+        // ell_0 = xi * I (assigned by check_ell_0)
+        out_coeffs.ell_0.evaluate();
+        // ell_vw = -H
+        out_coeffs.ell_vw.evaluate();
+        // ell_vv = 3 * J
+        out_coeffs.ell_vv.evaluate();
+    }
+};
+
+} // namespace libzecale
+
+#endif // __ZECALE_CIRCUITS_PAIRING_BLS12_377_PAIRING_HPP__

--- a/libzecale/circuits/pairing/bls12_377_pairing.hpp
+++ b/libzecale/circuits/pairing/bls12_377_pairing.hpp
@@ -245,7 +245,7 @@ public:
     void generate_r1cs_constraints();
 
     /// The Qx and Qy variables passed to the constructor must have been
-    /// assigned
+    /// assigned.
     void generate_r1cs_witness();
 };
 

--- a/libzecale/circuits/pairing/bls12_377_pairing.tcc
+++ b/libzecale/circuits/pairing/bls12_377_pairing.tcc
@@ -140,26 +140,28 @@ bls12_377_ate_dbl_gadget<ppT>::bls12_377_ate_dbl_gadget(
     // check: (Y + Z)^2 == H + B + C
     , Y_plus_Z(in_R.Y + in_R.Z)
     , H_plus_B_plus_C(H + B + C)
-    , check_H(pb, Y_plus_Z, H_plus_B_plus_C, FMT(annotation_prefix, " check H"))
+    , check_H(pb, Y_plus_Z, H_plus_B_plus_C, FMT(annotation_prefix, " check_H"))
 
     // I = (E - B)
     , I(E + (B * -libff::Fr<ppT>::one()))
 
     // J = Rx^2
     , J(pb, FMT(annotation_prefix, " J"))
-    , check_J(pb, in_R.X, J, FMT(annotation_prefix, " check Rx^2"))
+    , check_J(pb, in_R.X, J, FMT(annotation_prefix, " check_J"))
 
     , E_squared(pb, FMT(annotation_prefix, " E^2"))
-    , check_E_squared(pb, E, E_squared, FMT(annotation_prefix, " check E^2"))
+    , check_E_squared(
+          pb, E, E_squared, FMT(annotation_prefix, " check_E_squared"))
 
     , G_squared(pb, FMT(annotation_prefix, " G^2"))
-    , check_G_squared(pb, G, G_squared, FMT(annotation_prefix, " check G^2"))
+    , check_G_squared(
+          pb, G, G_squared, FMT(annotation_prefix, " check_G_squared"))
 
     , B_minus_F(B + (F * -libff::Fr<ppT>::one()))
 
     // outRx = A * (B-F)
     , check_out_Rx(
-          pb, A, B_minus_F, out_R.X, FMT(annotation_prefix, " check outRx"))
+          pb, A, B_minus_F, out_R.X, FMT(annotation_prefix, " check_out_Rx"))
 
     // outRy = G^2 - 3E^2
     // check: outRy + E^2 + E^2 + E^2 == G^2  (TODO: not required)
@@ -170,9 +172,9 @@ bls12_377_ate_dbl_gadget<ppT>::bls12_377_ate_dbl_gadget(
           G_squared_minus_3_E_squared,
           {0}, // one
           out_R.Y,
-          FMT(annotation_prefix, " check outRy"))
+          FMT(annotation_prefix, " check_out_Ry"))
 
-    , check_out_Rz(pb, B, H, out_R.Z, FMT(annotation_prefix, " check outRz"))
+    , check_out_Rz(pb, B, H, out_R.Z, FMT(annotation_prefix, " check_out_Rz"))
 
     // ell_0 = xi * I
     // ell_vw = -H
@@ -199,10 +201,10 @@ void bls12_377_ate_dbl_gadget<ppT>::generate_r1cs_constraints()
     // G = (B + F) / 2 checked as 2 * G == B + F
     this->pb.add_r1cs_constraint(
         {1, 2 * G.c0, B.c0 + F.c0},
-        FMT(this->annotation_prefix, " check G.c0"));
+        FMT(this->annotation_prefix, " check_G.c0"));
     this->pb.add_r1cs_constraint(
         {1, 2 * G.c1, B.c1 + F.c1},
-        FMT(this->annotation_prefix, " check G.c1"));
+        FMT(this->annotation_prefix, " check_G.c1"));
 
     // H = (Y + Z) ^ 2 - (B + C)
     check_H.generate_r1cs_constraints();
@@ -321,36 +323,36 @@ bls12_377_ate_add_gadget<ppT>::bls12_377_ate_add_gadget(
 
     // A = Qy * Rz
     , A(pb, FMT(annotation_prefix, " A"))
-    , check_A(pb, base_Y, in_R.Z, A, FMT(annotation_prefix, " check A"))
+    , check_A(pb, base_Y, in_R.Z, A, FMT(annotation_prefix, " check_A"))
     // B = Qx * Rz;
     , B(pb, FMT(annotation_prefix, " B"))
-    , check_B(pb, base_X, in_R.Z, B, FMT(annotation_prefix, " check B"))
+    , check_B(pb, base_X, in_R.Z, B, FMT(annotation_prefix, " check_B"))
     // theta = Ry - A;
     , theta(in_R.Y + (A * -libff::Fr<ppT>::one()))
     // lambda = Rx - B;
     , lambda(in_R.X + (B * -libff::Fr<ppT>::one()))
     // C = theta.squared();
     , C(pb, FMT(annotation_prefix, " C"))
-    , check_C(pb, theta, C, FMT(annotation_prefix, " check C"))
+    , check_C(pb, theta, C, FMT(annotation_prefix, " check_C"))
     // D = lambda.squared();
     , D(pb, FMT(annotation_prefix, " D"))
-    , check_D(pb, lambda, D, FMT(annotation_prefix, " check D"))
+    , check_D(pb, lambda, D, FMT(annotation_prefix, " check_D"))
     // E = lambda * D;
     , E(pb, FMT(annotation_prefix, " E"))
-    , check_E(pb, lambda, D, E, FMT(annotation_prefix, " check E"))
+    , check_E(pb, lambda, D, E, FMT(annotation_prefix, " check_E"))
     // F = Rz * C;
     , F(pb, FMT(annotation_prefix, " F"))
-    , check_F(pb, in_R.Z, C, F, FMT(annotation_prefix, " check F"))
+    , check_F(pb, in_R.Z, C, F, FMT(annotation_prefix, " check_F"))
     // G = Rx * D;
     , G(pb, FMT(annotation_prefix, " G"))
-    , check_G(pb, in_R.X, D, G, FMT(annotation_prefix, " check G"))
+    , check_G(pb, in_R.X, D, G, FMT(annotation_prefix, " check_G"))
     // H = E + F - (G + G);
     , H(E + F + (G * -libff::Fr<ppT>(2)))
     // I = Ry * E;
     , I(pb, FMT(annotation_prefix, " I"))
-    , check_I(pb, in_R.Y, E, I, FMT(annotation_prefix, " check I"))
+    , check_I(pb, in_R.Y, E, I, FMT(annotation_prefix, " check_I"))
     // J = theta * Qx - lambda * Qy;
-    , theta_times_Qx(pb, FMT(annotation_prefix, " theta_times_Rx"))
+    , theta_times_Qx(pb, FMT(annotation_prefix, " theta_times_Qx"))
     , check_theta_times_Qx(
           pb,
           theta,
@@ -382,7 +384,7 @@ bls12_377_ate_add_gadget<ppT>::bls12_377_ate_add_gadget(
           FMT(annotation_prefix, " check_theta_times_G_minus_H"))
     // out_Rz = Rza * E;
     , out_Rz(pb, FMT(annotation_prefix, " out_Rz"))
-    , check_out_Rz(pb, in_R.Z, E, out_Rz, FMT(annotation_prefix, " check Rz"))
+    , check_out_Rz(pb, in_R.Z, E, out_Rz, FMT(annotation_prefix, " check_Rz"))
 
     , out_R(
           out_Rx, theta_times_G_minus_H + (I * -libff::Fr<ppT>::one()), out_Rz)
@@ -499,7 +501,7 @@ bls12_377_ate_precompute_gadget<ppT>::bls12_377_ate_precompute_gadget(
             new bls12_377_ate_dbl_gadget<ppT>(
                 pb,
                 *currentR,
-                FMT(annotation_prefix, " dbl %zu", bits.index()))));
+                FMT(annotation_prefix, " dbls[%zu]", bits.index()))));
         currentR = &_ate_dbls.back()->out_R;
 
         if (bits.current()) {
@@ -509,7 +511,7 @@ bls12_377_ate_precompute_gadget<ppT>::bls12_377_ate_precompute_gadget(
                     _Qx,
                     _Qy,
                     *currentR,
-                    FMT(annotation_prefix, " add %zu", bits.index()))));
+                    FMT(annotation_prefix, " adds[%zu]", bits.index()))));
             currentR = &_ate_adds.back()->out_R;
         }
     }
@@ -568,22 +570,22 @@ bls12_377_ate_compute_f_ell_P<ppT>::bls12_377_ate_compute_f_ell_P(
           pb,
           ell_coeffs.ell_vv,
           Px,
-          libsnark::Fqe_variable<ppT>(pb, FMT(annotation_prefix, "Px.ell_vv")),
-          FMT(annotation_prefix, "check Px.ell_vv"))
+          libsnark::Fqe_variable<ppT>(pb, FMT(annotation_prefix, " Px.ell_vv")),
+          FMT(annotation_prefix, " _ell_vv_times_Px"))
     , _ell_vw_times_Py(
           pb,
           ell_coeffs.ell_vw,
           Py,
-          libsnark::Fqe_variable<ppT>(pb, FMT(annotation_prefix, "Py.ell_vw")),
-          FMT(annotation_prefix, "check Py.ell_vw"))
+          libsnark::Fqe_variable<ppT>(pb, FMT(annotation_prefix, " Py.ell_vw")),
+          FMT(annotation_prefix, " _ell_vw_times_Py"))
     , _f_mul_ell_P(
           pb,
           f,
           ell_coeffs.ell_0,
           _ell_vv_times_Px.result,
           _ell_vw_times_Py.result,
-          Fp12_2over3over2_variable<FqkT>(pb, FMT(annotation_prefix, "new f")),
-          FMT(annotation_prefix, " f.ell(P)"))
+          Fp12_2over3over2_variable<FqkT>(pb, FMT(annotation_prefix, " new_f")),
+          FMT(annotation_prefix, " _f_mul_ell_P"))
 {
 }
 
@@ -625,8 +627,8 @@ bls12_377_ate_miller_loop_gadget<ppT>::bls12_377_ate_miller_loop_gadget(
     , _Py(Py)
     , _Qx(Qx)
     , _Qy(Qy)
-    , _Q_precomp(pb, Qx, Qy, FMT(annotation_prefix, " preecompute"))
-    , _f0(pb, FqkT::one(), FMT(annotation_prefix, "f0"))
+    , _Q_precomp(pb, Qx, Qy, FMT(annotation_prefix, " _Q_precomp"))
+    , _f0(pb, FqkT::one(), FMT(annotation_prefix, " f0"))
 {
     const std::vector<std::shared_ptr<bls12_377_ate_dbl_gadget<ppT>>>
         &ate_dbls = _Q_precomp._ate_dbls;
@@ -646,7 +648,10 @@ bls12_377_ate_miller_loop_gadget<ppT>::bls12_377_ate_miller_loop_gadget(
         _f_squared.push_back(
             std::shared_ptr<Fp12_2over3over2_square_gadget<FqkT>>(
                 new Fp12_2over3over2_square_gadget<FqkT>(
-                    pb, *f, f_squared, FMT(annotation_prefix, " comp f^2"))));
+                    pb,
+                    *f,
+                    f_squared,
+                    FMT(annotation_prefix, " compute_f^2"))));
 
         // f <- f^2 * ell(P)
         _f_ell_P.push_back(std::shared_ptr<bls12_377_ate_compute_f_ell_P<ppT>>(
@@ -656,7 +661,7 @@ bls12_377_ate_miller_loop_gadget<ppT>::bls12_377_ate_miller_loop_gadget(
                 Py,
                 ate_dbls[dbl_idx++]->out_coeffs,
                 f_squared,
-                FMT(annotation_prefix, "check f^2*ell(P)"))));
+                FMT(annotation_prefix, " f^2*ell(P)"))));
         f = &_f_ell_P.back()->result();
 
         if (bits.current()) {
@@ -669,7 +674,7 @@ bls12_377_ate_miller_loop_gadget<ppT>::bls12_377_ate_miller_loop_gadget(
                         Py,
                         ate_adds[add_idx++]->out_coeffs,
                         *f,
-                        FMT(annotation_prefix, "check f*ell(P)"))));
+                        FMT(annotation_prefix, " f*ell(P)"))));
             f = &_f_ell_P.back()->result();
         }
     }

--- a/libzecale/circuits/pairing/bls12_377_pairing.tcc
+++ b/libzecale/circuits/pairing/bls12_377_pairing.tcc
@@ -312,21 +312,21 @@ void bls12_377_ate_dbl_gadget<ppT>::generate_r1cs_witness(
 template<typename ppT>
 bls12_377_ate_add_gadget<ppT>::bls12_377_ate_add_gadget(
     libsnark::protoboard<libff::Fr<ppT>> &pb,
-    const libsnark::Fqe_variable<ppT> &base_X,
-    const libsnark::Fqe_variable<ppT> &base_Y,
+    const libsnark::Fqe_variable<ppT> &in_Q_X,
+    const libsnark::Fqe_variable<ppT> &in_Q_Y,
     const bls12_377_G2_proj<ppT> &R,
     const std::string &annotation_prefix)
     : libsnark::gadget<libff::Fr<ppT>>(pb, annotation_prefix)
-    , base_X(base_X)
-    , base_Y(base_Y)
+    , Q_X(in_Q_X)
+    , Q_Y(in_Q_Y)
     , in_R(R)
 
     // A = Qy * Rz
     , A(pb, FMT(annotation_prefix, " A"))
-    , check_A(pb, base_Y, in_R.Z, A, FMT(annotation_prefix, " check_A"))
+    , check_A(pb, Q_Y, in_R.Z, A, FMT(annotation_prefix, " check_A"))
     // B = Qx * Rz;
     , B(pb, FMT(annotation_prefix, " B"))
-    , check_B(pb, base_X, in_R.Z, B, FMT(annotation_prefix, " check_B"))
+    , check_B(pb, Q_X, in_R.Z, B, FMT(annotation_prefix, " check_B"))
     // theta = Ry - A;
     , theta(in_R.Y + (A * -libff::Fr<ppT>::one()))
     // lambda = Rx - B;
@@ -356,14 +356,14 @@ bls12_377_ate_add_gadget<ppT>::bls12_377_ate_add_gadget(
     , check_theta_times_Qx(
           pb,
           theta,
-          base_X,
+          Q_X,
           theta_times_Qx,
           FMT(annotation_prefix, " check_theta_times_Qx"))
     , lambda_times_Qy(pb, FMT(annotation_prefix, " lambda_times_Qy"))
     , check_lambda_times_Qy(
           pb,
           lambda,
-          base_Y,
+          Q_Y,
           lambda_times_Qy,
           FMT(annotation_prefix, " check_lambda_times_Qy"))
     , J(theta_times_Qx + (lambda_times_Qy * -libff::Fr<ppT>::one()))

--- a/libzecale/circuits/pairing/bls12_377_pairing.tcc
+++ b/libzecale/circuits/pairing/bls12_377_pairing.tcc
@@ -1,0 +1,445 @@
+// Copyright (c) 2015-2020 Clearmatics Technologies Ltd
+//
+// SPDX-License-Identifier: LGPL-3.0+
+
+#ifndef __ZECALE_CIRCUITS_PAIRING_BLS12_377_PAIRING_TCC__
+#define __ZECALE_CIRCUITS_PAIRING_BLS12_377_PAIRING_TCC__
+
+namespace libzecale
+{
+
+// bls12_377_G2_proj methods
+
+template<typename ppT>
+bls12_377_G2_proj<ppT>::bls12_377_G2_proj(
+    libsnark::protoboard<libff::Fr<ppT>> &pb,
+    const std::string &annotation_prefix)
+    : X(pb, FMT(annotation_prefix, " X"))
+    , Y(pb, FMT(annotation_prefix, " Y"))
+    , Z(pb, FMT(annotation_prefix, " Z"))
+{
+}
+
+template<typename ppT>
+bls12_377_G2_proj<ppT>::bls12_377_G2_proj(
+    const libsnark::Fqe_variable<ppT> &X_var,
+    const libsnark::Fqe_variable<ppT> &Y_var,
+    const libsnark::Fqe_variable<ppT> &Z_var)
+    : X(X_var), Y(Y_var), Z(Z_var)
+{
+}
+
+template<typename ppT> void bls12_377_G2_proj<ppT>::evaluate() const
+{
+    X.evaluate();
+    Y.evaluate();
+    Z.evaluate();
+}
+
+template<typename ppT>
+void bls12_377_G2_proj<ppT>::generate_r1cs_witness(
+    const libff::bls12_377_G2 &element)
+{
+    X.generate_r1cs_witness(element.X);
+    Y.generate_r1cs_witness(element.Y);
+    Z.generate_r1cs_witness(element.Z);
+}
+
+// bls12_377_ate_ell_coeffs methods
+
+template<typename ppT>
+bls12_377_ate_ell_coeffs<ppT>::bls12_377_ate_ell_coeffs(
+    const libsnark::Fqe_variable<ppT> &ell_0,
+    const libsnark::Fqe_variable<ppT> &ell_vw,
+    const libsnark::Fqe_variable<ppT> &ell_vv)
+    : ell_0(ell_0), ell_vw(ell_vw), ell_vv(ell_vv)
+{
+}
+
+template<typename ppT> void bls12_377_ate_ell_coeffs<ppT>::evaluate() const
+{
+    ell_0.evaluate();
+    ell_vw.evaluate();
+    ell_vv.evaluate();
+}
+
+// bls12_377_ate_dbl_gadget methods
+
+template<typename ppT>
+bls12_377_ate_dbl_gadget<ppT>::bls12_377_ate_dbl_gadget(
+    libsnark::protoboard<FqT> &pb,
+    const bls12_377_G2_proj<ppT> &R,
+    const std::string &annotation_prefix)
+    : libsnark::gadget<libff::Fr<ppT>>(pb, annotation_prefix)
+    , in_R(R)
+    , out_R(pb, " R")
+
+    // A = Rx * Ry / 2
+    , A(pb, FMT(annotation_prefix, " A"))
+    , check_A(
+          pb, in_R.X, in_R.Y, A * FqT(2), FMT(annotation_prefix, " check_A"))
+
+    // B = Ry^2
+    , B(pb, FMT(annotation_prefix, " B"))
+    , check_B(pb, in_R.Y, B, FMT(annotation_prefix, " check_B"))
+
+    // C = Rz^2
+    , C(pb, FMT(annotation_prefix, " C"))
+    , check_C(pb, in_R.Z, C, FMT(annotation_prefix, "check_C"))
+
+    // D = 3 * C
+    // , D(C * FqT(3))
+
+    // E = b' * D
+    , E((C * libff::Fr<ppT>(3)) * libff::bls12_377_twist_coeff_b)
+
+    // F = 3 * E
+    , F(E + E + E)
+
+    // G = (B + F) / 2  (added manually)
+    , G(pb, FMT(annotation_prefix, " G"))
+
+    // H = (Y + Z) ^ 2 - (B + C)
+    , H(pb, FMT(annotation_prefix, " H"))
+    // check: (Y + Z)^2 == H + B + C
+    , Y_plus_Z(in_R.Y + in_R.Z)
+    , H_plus_B_plus_C(H + B + C)
+    , check_H(pb, Y_plus_Z, H_plus_B_plus_C, FMT(annotation_prefix, " check H"))
+
+    // I = (E - B)
+    , I(E + (B * -libff::Fr<ppT>::one()))
+
+    // J = Rx^2
+    , J(pb, FMT(annotation_prefix, " J"))
+    , check_J(pb, in_R.X, J, FMT(annotation_prefix, " check Rx^2"))
+
+    , E_squared(pb, FMT(annotation_prefix, " E^2"))
+    , check_E_squared(pb, E, E_squared, FMT(annotation_prefix, " check E^2"))
+
+    , G_squared(pb, FMT(annotation_prefix, " G^2"))
+    , check_G_squared(pb, G, G_squared, FMT(annotation_prefix, " check G^2"))
+
+    , B_minus_F(B + (F * -libff::Fr<ppT>::one()))
+
+    // outRx = A * (B-F)
+    , check_out_Rx(
+          pb, A, B_minus_F, out_R.X, FMT(annotation_prefix, " check outRx"))
+
+    // outRy = G^2 - 3E^2
+    // check: outRy + E^2 + E^2 + E^2 == G^2  (TODO: not required)
+    , G_squared_minus_3_E_squared(
+          G_squared + (E_squared * -libff::Fr<ppT>("3")))
+    , check_out_Ry(
+          pb,
+          G_squared_minus_3_E_squared,
+          {0}, // one
+          out_R.Y,
+          FMT(annotation_prefix, " check outRy"))
+
+    , check_out_Rz(pb, B, H, out_R.Z, FMT(annotation_prefix, " check outRz"))
+
+    // ell_0 = xi * I
+    // ell_vw = -H
+    // ell_vv = 3 * J
+    , out_coeffs(
+          I * libff::bls12_377_twist,
+          H * -libff::Fr<ppT>(1),
+          J * libff::Fr<ppT>(3))
+{
+}
+
+template<typename ppT>
+void bls12_377_ate_dbl_gadget<ppT>::generate_r1cs_constraints()
+{
+    check_A.generate_r1cs_constraints();
+    check_B.generate_r1cs_constraints();
+    check_C.generate_r1cs_constraints();
+
+    // D = 3 * C
+    // E = b' * D
+    //   = b' * (C + C + C)  (2 constraints for mul by Fq2 constant)
+    // F = 3 * E
+
+    // G = (B + F) / 2 checked as 2 * G == B + F
+    this->pb.add_r1cs_constraint(
+        {1, 2 * G.c0, B.c0 + F.c0},
+        FMT(this->annotation_prefix, " check G.c0"));
+    this->pb.add_r1cs_constraint(
+        {1, 2 * G.c1, B.c1 + F.c1},
+        FMT(this->annotation_prefix, " check G.c1"));
+
+    // H = (Y + Z) ^ 2 - (B + C)
+    check_H.generate_r1cs_constraints();
+
+    // I = E - B
+    // J = Rx^2
+    check_J.generate_r1cs_constraints();
+
+    // E_squared
+    check_E_squared.generate_r1cs_constraints();
+
+    // G_squared
+    check_G_squared.generate_r1cs_constraints();
+
+    // B_minus_F
+    // check_B_minus_F.generate_r1cs_constraints();
+
+    // outRx = A * (B - F)
+    check_out_Rx.generate_r1cs_constraints();
+
+    // outRy = G^2 - 3 * E^2
+    check_out_Ry.generate_r1cs_constraints();
+
+    // outRz = B * H
+    check_out_Rz.generate_r1cs_constraints();
+
+    // There are just linear combinations, so no need for constraints:
+    // ell_0 = xi * I
+    // ell_vw = -H
+    // ell_vv = 3 * J
+}
+
+template<typename ppT>
+void bls12_377_ate_dbl_gadget<ppT>::generate_r1cs_witness(
+    const libff::Fr<ppT> &two_inv)
+{
+    const FqeT Rx = in_R.X.get_element();
+    const FqeT Ry = in_R.Y.get_element();
+    const FqeT Rz = in_R.Z.get_element();
+
+    // A = Rx * Ry / 2
+    A.generate_r1cs_witness(two_inv * Rx * Ry);
+    check_A.generate_r1cs_witness();
+
+    // B = Ry^2
+    check_B.generate_r1cs_witness();
+
+    // C = Rz^2
+    check_C.generate_r1cs_witness();
+
+    // D = 3 * C
+    // D.generate_r1cs_witness();
+
+    // E = b' * D
+    E.evaluate();
+    assert(
+        E.get_element() ==
+        libff::Fr<ppT>(3) * C.get_element() * libff::bls12_377_twist_coeff_b);
+
+    // F = 3 * E (linear comb)
+    F.evaluate();
+    assert(F.get_element() == libff::Fr<ppT>(3) * E.get_element());
+
+    // G = (B + F) / 2
+    G.generate_r1cs_witness(two_inv * (B.get_element() + F.get_element()));
+
+    // H = (Y + Z) ^ 2 - (B + C)
+    const FqeT Y_plus_Z_squared = (Ry + Rz).squared();
+    H.generate_r1cs_witness(
+        Y_plus_Z_squared - B.get_element() - C.get_element());
+    check_H.generate_r1cs_witness();
+
+    // I = E - B
+    I.evaluate();
+
+    // J = Rx^2
+    check_J.generate_r1cs_witness();
+
+    // E^2
+    check_E_squared.generate_r1cs_witness();
+
+    // G^2
+    check_G_squared.generate_r1cs_witness();
+
+    // out_Rx = A * (B - F) (assigned by check_outRx)
+    B_minus_F.evaluate();
+    assert(B.get_element() - F.get_element() == B_minus_F.get_element());
+    check_out_Rx.generate_r1cs_witness();
+
+    // out_Ry = G^2 - 3 * E^2
+    G_squared_minus_3_E_squared.evaluate();
+    check_out_Ry.generate_r1cs_witness();
+
+    // out_Rz = B * H (assigned by check_outRz)
+    check_out_Rz.generate_r1cs_witness();
+
+    // ell_0 = xi * I (assigned by check_ell_0)
+    // ell_vw = -H
+    // ell_vv = 3 * J
+    out_coeffs.evaluate();
+}
+
+// bls12_377_ate_add_gadget methods
+
+template<typename ppT>
+bls12_377_ate_add_gadget<ppT>::bls12_377_ate_add_gadget(
+    libsnark::protoboard<libff::Fr<ppT>> &pb,
+    const libsnark::Fqe_variable<ppT> &base_X,
+    const libsnark::Fqe_variable<ppT> &base_Y,
+    const bls12_377_G2_proj<ppT> &R,
+    const std::string &annotation_prefix)
+    : libsnark::gadget<libff::Fr<ppT>>(pb, annotation_prefix)
+    , base_X(base_X)
+    , base_Y(base_Y)
+    , in_R(R)
+
+    // A = Qy * Rz
+    , A(pb, FMT(annotation_prefix, " A"))
+    , check_A(pb, base_Y, in_R.Z, A, FMT(annotation_prefix, " check A"))
+    // B = Qx * Rz;
+    , B(pb, FMT(annotation_prefix, " B"))
+    , check_B(pb, base_X, in_R.Z, B, FMT(annotation_prefix, " check B"))
+    // theta = Ry - A;
+    , theta(in_R.Y + (A * -libff::Fr<ppT>::one()))
+    // lambda = Rx - B;
+    , lambda(in_R.X + (B * -libff::Fr<ppT>::one()))
+    // C = theta.squared();
+    , C(pb, FMT(annotation_prefix, " C"))
+    , check_C(pb, theta, C, FMT(annotation_prefix, " check C"))
+    // D = lambda.squared();
+    , D(pb, FMT(annotation_prefix, " D"))
+    , check_D(pb, lambda, D, FMT(annotation_prefix, " check D"))
+    // E = lambda * D;
+    , E(pb, FMT(annotation_prefix, " E"))
+    , check_E(pb, lambda, D, E, FMT(annotation_prefix, " check E"))
+    // F = Rz * C;
+    , F(pb, FMT(annotation_prefix, " F"))
+    , check_F(pb, in_R.Z, C, F, FMT(annotation_prefix, " check F"))
+    // G = Rx * D;
+    , G(pb, FMT(annotation_prefix, " G"))
+    , check_G(pb, in_R.X, D, G, FMT(annotation_prefix, " check G"))
+    // H = E + F - (G + G);
+    , H(E + F + (G * -libff::Fr<ppT>(2)))
+    // I = Ry * E;
+    , I(pb, FMT(annotation_prefix, " I"))
+    , check_I(pb, in_R.Y, E, I, FMT(annotation_prefix, " check I"))
+    // J = theta * Qx - lambda * Qy;
+    , theta_times_Qx(pb, FMT(annotation_prefix, " theta_times_Rx"))
+    , check_theta_times_Qx(
+          pb,
+          theta,
+          base_X,
+          theta_times_Qx,
+          FMT(annotation_prefix, " check_theta_times_Qx"))
+    , lambda_times_Qy(pb, FMT(annotation_prefix, " lambda_times_Qy"))
+    , check_lambda_times_Qy(
+          pb,
+          lambda,
+          base_Y,
+          lambda_times_Qy,
+          FMT(annotation_prefix, " check_lambda_times_Qy"))
+    , J(theta_times_Qx + (lambda_times_Qy * -libff::Fr<ppT>::one()))
+
+    // out_Rx = lambda * H;
+    , out_Rx(pb, FMT(annotation_prefix, " out_Rx"))
+    , check_out_Rx(
+          pb, lambda, H, out_Rx, FMT(annotation_prefix, " check out_Rx"))
+    // out_Ry = theta * (G - H) - I;
+    , G_minus_H(G + (H * -libff::Fr<ppT>::one()))
+    , theta_times_G_minus_H(
+          pb, FMT(annotation_prefix, " theta_times_G_minus_H"))
+    , check_theta_times_G_minus_H(
+          pb,
+          theta,
+          G_minus_H,
+          theta_times_G_minus_H,
+          FMT(annotation_prefix, " check_theta_times_G_minus_H"))
+    // out_Rz = Rza * E;
+    , out_Rz(pb, FMT(annotation_prefix, " out_Rz"))
+    , check_out_Rz(pb, in_R.Z, E, out_Rz, FMT(annotation_prefix, " check Rz"))
+
+    , out_R(
+          out_Rx, theta_times_G_minus_H + (I * -libff::Fr<ppT>::one()), out_Rz)
+
+    // out_coeffs.ell_0 = xi * J;
+    // out_coeffs.ell_vw = lambda;
+    // out_coeffs.ell_vv = -theta;
+    , out_coeffs(
+          J * libff::bls12_377_twist, lambda, theta * -libff::Fr<ppT>::one())
+{
+}
+
+template<typename ppT>
+void bls12_377_ate_add_gadget<ppT>::generate_r1cs_constraints()
+{
+    // A = Ry * Rz  (A assigned by check_A)
+    check_A.generate_r1cs_constraints();
+    // B = Rx * Rz  (B assigned by check_B)
+    check_B.generate_r1cs_constraints();
+    // theta = Ry - A;
+    // lambda = Rx - B;
+    // C = theta.squared()  (C assigned by check_C)
+    check_C.generate_r1cs_constraints();
+    // D = lambda.squared();
+    check_D.generate_r1cs_constraints();
+    // E = lambda * D;
+    check_E.generate_r1cs_constraints();
+    // F = Rz * C;
+    check_F.generate_r1cs_constraints();
+    // G = Rx * D;
+    check_G.generate_r1cs_constraints();
+    // H = E + F - (G + G);
+    // I = Ry * E;
+    check_I.generate_r1cs_constraints();
+    // J = theta * Qx - lambda * Qy;
+    check_theta_times_Qx.generate_r1cs_constraints();
+    check_lambda_times_Qy.generate_r1cs_constraints();
+    // out_Rx = lambda * H;
+    check_out_Rx.generate_r1cs_constraints();
+    // out_Ry = theta * (G - H) - I;
+    check_theta_times_G_minus_H.generate_r1cs_constraints();
+    // out_Rz = Z1 * E;
+    check_out_Rz.generate_r1cs_constraints();
+    // out_coeffs.ell_0 = xi * J;
+    // out_coeffs.ell_VV = -theta;
+    // out_coeffs.ell_VW = lambda;
+}
+
+template<typename ppT>
+void bls12_377_ate_add_gadget<ppT>::generate_r1cs_witness()
+{
+    // A = Ry * Rz  (A assigned by check_A)
+    check_A.generate_r1cs_witness();
+    // B = Rx * Rz  (B assigned by check_B)
+    check_B.generate_r1cs_witness();
+    // theta = Ry - A;
+    theta.evaluate();
+    // lambda = Rx - B;
+    lambda.evaluate();
+    // C = theta.squared()  (C assigned by check_C)
+    check_C.generate_r1cs_witness();
+    // D = lambda.squared()  (D assigned by check_D)
+    check_D.generate_r1cs_witness();
+    // E = lambda * D  (E assigned by check_E)
+    check_E.generate_r1cs_witness();
+    // F = Rz * C  (F assigned by check_F)
+    check_F.generate_r1cs_witness();
+    // G = Rx * D;
+    check_G.generate_r1cs_witness();
+    // H = E + F - (G + G);
+    H.evaluate();
+    // I = Ry * E  (I assigned by check_I)
+    check_I.generate_r1cs_witness();
+    // J = theta * Qx - lambda * Qy;
+    check_theta_times_Qx.generate_r1cs_witness();
+    check_lambda_times_Qy.generate_r1cs_witness();
+    J.evaluate();
+
+    // out_Rx = lambda * H (assigned by check_out_Rx)
+    check_out_Rx.generate_r1cs_witness();
+    // out_Ry = theta * (G - H) - I;
+    G_minus_H.evaluate();
+    check_theta_times_G_minus_H.generate_r1cs_witness();
+    // out_Rz = Z1 * E (assigned by check_out_Rz)
+    check_out_Rz.generate_r1cs_witness();
+    out_R.evaluate();
+
+    // out_coeffs.ell_0 = xi * J;
+    // out_coeffs.ell_vw = lambda;
+    // out_coeffs.ell_vv = -theta;
+    out_coeffs.evaluate();
+}
+
+} // namespace libzecale
+
+#endif // __ZECALE_CIRCUITS_PAIRING_BLS12_377_PAIRING_TCC__

--- a/libzecale/circuits/pairing/bls12_377_pairing.tcc
+++ b/libzecale/circuits/pairing/bls12_377_pairing.tcc
@@ -5,6 +5,8 @@
 #ifndef __ZECALE_CIRCUITS_PAIRING_BLS12_377_PAIRING_TCC__
 #define __ZECALE_CIRCUITS_PAIRING_BLS12_377_PAIRING_TCC__
 
+#include "libzecale/circuits/pairing/bls12_377_pairing.hpp"
+
 namespace libzecale
 {
 

--- a/libzecale/circuits/pairing/bw6_761_pairing_params.hpp
+++ b/libzecale/circuits/pairing/bw6_761_pairing_params.hpp
@@ -5,6 +5,7 @@
 #ifndef __ZECALE_CIRCUITS_PAIRING_BW6_761_PAIRING_PARAMS_HPP__
 #define __ZECALE_CIRCUITS_PAIRING_BW6_761_PAIRING_PARAMS_HPP__
 
+#include "libzecale/circuits/fields/fp12_2over3over2_gadgets.hpp"
 #include "libzecale/circuits/pairing/pairing_params.hpp"
 
 #include <libff/algebra/curves/bls12_377/bls12_377_pp.hpp>
@@ -35,11 +36,11 @@ public:
     typedef libsnark::Fp2_mul_by_lc_gadget<FqeT> Fqe_mul_by_lc_gadget_type;
     typedef libsnark::Fp2_sqr_gadget<FqeT> Fqe_sqr_gadget_type;
 
-    // typedef libsnark::Fp12_variable<FqkT> Fqk_variable_type;
+    typedef Fp12_2over3over2_variable<FqkT> Fqk_variable_type;
     // typedef libsnark::Fp12_mul_gadget<FqkT> Fqk_mul_gadget_type;
     // typedef libsnark::Fp12_mul_by_2345_gadget<FqkT>
-    // Fqk_special_mul_gadget_type; typedef libsnark::Fp12_sqr_gadget<FqkT>
-    // Fqk_sqr_gadget_type;
+    typedef Fp12_2over3over2_mul_by_024_gadget<FqkT> Fqk_mul_by_024_gadget_type;
+    typedef Fp12_2over3over2_square_gadget<FqkT> Fqk_sqr_gadget_type;
 
     typedef libff::bls12_377_pp other_curve_type;
 

--- a/libzecale/circuits/pairing/bw6_761_pairing_params.hpp
+++ b/libzecale/circuits/pairing/bw6_761_pairing_params.hpp
@@ -1,0 +1,71 @@
+// Copyright (c) 2015-2020 Clearmatics Technologies Ltd
+//
+// SPDX-License-Identifier: LGPL-3.0+
+
+#ifndef __ZECALE_CIRCUITS_PAIRING_BW6_761_PAIRING_PARAMS_HPP__
+#define __ZECALE_CIRCUITS_PAIRING_BW6_761_PAIRING_PARAMS_HPP__
+
+#include "libzecale/circuits/pairing/pairing_params.hpp"
+
+#include <libff/algebra/curves/bls12_377/bls12_377_pp.hpp>
+#include <libff/algebra/curves/bw6_761/bw6_761_pp.hpp>
+#include <libsnark/gadgetlib1/gadgets/fields/fp2_gadgets.hpp>
+#include <libsnark/gadgetlib1/gadgets/pairing/pairing_params.hpp>
+
+namespace libzecale
+{
+
+// Parameters for creating BW6-761 proofs that include statements about
+// BLS12_377 pairings.
+class bw6_761_pairing_selector
+{
+public:
+    static_assert(
+        std::is_same<
+            libff::Fr<libff::bw6_761_pp>,
+            libff::Fq<libff::bls12_377_pp>>::value,
+        "Field types do not match");
+
+    typedef libff::Fr<libff::bw6_761_pp> FieldT;
+    typedef libff::Fqe<libff::bls12_377_pp> FqeT;
+    typedef libff::Fqk<libff::bls12_377_pp> FqkT;
+
+    typedef libsnark::Fp2_variable<FqeT> Fqe_variable_type;
+    typedef libsnark::Fp2_mul_gadget<FqeT> Fqe_mul_gadget_type;
+    typedef libsnark::Fp2_mul_by_lc_gadget<FqeT> Fqe_mul_by_lc_gadget_type;
+    typedef libsnark::Fp2_sqr_gadget<FqeT> Fqe_sqr_gadget_type;
+
+    // typedef libsnark::Fp12_variable<FqkT> Fqk_variable_type;
+    // typedef libsnark::Fp12_mul_gadget<FqkT> Fqk_mul_gadget_type;
+    // typedef libsnark::Fp12_mul_by_2345_gadget<FqkT>
+    // Fqk_special_mul_gadget_type; typedef libsnark::Fp12_sqr_gadget<FqkT>
+    // Fqk_sqr_gadget_type;
+
+    typedef libff::bls12_377_pp other_curve_type;
+
+    // typedef bls12_377_e_over_e_miller_loop_gadget
+    //     bls12_377_over_e_miller_loop_gadget_type;
+    // typedef bls12_377_e_times_e_over_e_miller_loop_gadget
+    //     e_times_e_over_e_miller_loop_gadget_type;
+    // typedef bls12_377_e_times_e_times_e_over_e_miller_loop_gadget
+    //     e_times_e_times_e_over_e_miller_loop_gadget_type;
+    // typedef bls12_377_final_exp_gadget final_exp_gadget_type;
+
+    static const constexpr libff::bigint<libff::bw6_761_Fr::num_limbs>
+        &pairing_loop_count = libff::bls12_377_ate_loop_count;
+};
+
+} // namespace libzecale
+
+namespace libsnark
+{
+
+template<>
+class pairing_selector<libff::bw6_761_pp>
+    : public libzecale::bw6_761_pairing_selector
+{
+};
+
+} // namespace libsnark
+
+#endif // __ZECALE_CIRCUITS_PAIRING_BW6_761_PAIRING_PARAMS_HPP__

--- a/libzecale/tests/CMakeLists.txt
+++ b/libzecale/tests/CMakeLists.txt
@@ -27,6 +27,8 @@ function(zecale_test TEST_NAME)
     protobuf::libprotobuf
   )
 
+  target_include_directories(${TEST_NAME} PUBLIC zecale)
+
   # Add all tests to the 'build_tests' target
   add_dependencies(build_tests ${TEST_NAME})
 

--- a/libzecale/tests/circuits/bls12_377_pairing_test.cpp
+++ b/libzecale/tests/circuits/bls12_377_pairing_test.cpp
@@ -12,11 +12,9 @@
 #include <libsnark/gadgetlib1/gadgets/pairing/pairing_params.hpp>
 #include <libzeth/snarks/groth16/groth16_snark.hpp>
 
-using ppp = libff::bw6_761_pp; // Parent pairing
-using ps = libsnark::pairing_selector<ppp>;
-using cpp = ps::other_curve_type; // Child pairing
-
-using snark = libzeth::groth16_snark<ppp>;
+using wpp = libff::bw6_761_pp;
+using npp = libsnark::other_curve<wpp>;
+using snark = libzeth::groth16_snark<wpp>;
 
 namespace
 {
@@ -37,16 +35,16 @@ TEST(BLS12_377_PairingTest, PrecomputeDoubleGadgetTest)
 
     // Create and populate protoboard
 
-    libsnark::protoboard<libff::Fr<ppp>> pb;
+    libsnark::protoboard<libff::Fr<wpp>> pb;
 
-    libzecale::bls12_377_G2_proj<ppp> R0_var(pb, "R0");
+    libzecale::bls12_377_G2_proj<wpp> R0_var(pb, "R0");
 
     const size_t num_primary_inputs = pb.num_inputs();
     pb.set_input_sizes(num_primary_inputs);
     std::cout << "num_primary_inputs: " << std::to_string(num_primary_inputs)
               << "\n";
 
-    libzecale::bls12_377_ate_dbl_gadget<ppp> check_double_R0(
+    libzecale::bls12_377_ate_dbl_gadget<wpp> check_double_R0(
         pb, R0_var, "check R1");
 
     check_double_R0.generate_r1cs_constraints();
@@ -58,38 +56,38 @@ TEST(BLS12_377_PairingTest, PrecomputeDoubleGadgetTest)
 
     // Check values
 
-    const libzecale::bls12_377_G2_proj<ppp> &R1_var = check_double_R0.out_R;
-    const libzecale::bls12_377_ate_ell_coeffs<ppp> &R1_coeffs_var =
+    const libzecale::bls12_377_G2_proj<wpp> &R1_var = check_double_R0.out_R;
+    const libzecale::bls12_377_ate_ell_coeffs<wpp> &R1_coeffs_var =
         check_double_R0.out_coeffs;
 
-    const libff::Fqe<cpp> A = check_double_R0.A.get_element();
-    const libff::Fqe<cpp> B = check_double_R0.B.get_element();
-    const libff::Fqe<cpp> C = check_double_R0.C.get_element();
-    const libff::Fqe<cpp> E = check_double_R0.E.get_element();
-    const libff::Fqe<cpp> F = check_double_R0.F.get_element();
-    const libff::Fqe<cpp> G = check_double_R0.G.get_element();
-    const libff::Fqe<cpp> H = check_double_R0.H.get_element();
-    const libff::Fqe<cpp> I = check_double_R0.I.get_element();
-    const libff::Fqe<cpp> J = check_double_R0.J.get_element();
-    const libff::Fqe<cpp> E_squared = check_double_R0.E_squared.get_element();
-    const libff::Fqe<cpp> G_squared = check_double_R0.G_squared.get_element();
-    const libff::Fqe<cpp> B_minus_F = check_double_R0.B_minus_F.get_element();
-    const libff::Fqe<cpp> G_squared_minus_3_E_squared =
+    const libff::Fqe<npp> A = check_double_R0.A.get_element();
+    const libff::Fqe<npp> B = check_double_R0.B.get_element();
+    const libff::Fqe<npp> C = check_double_R0.C.get_element();
+    const libff::Fqe<npp> E = check_double_R0.E.get_element();
+    const libff::Fqe<npp> F = check_double_R0.F.get_element();
+    const libff::Fqe<npp> G = check_double_R0.G.get_element();
+    const libff::Fqe<npp> H = check_double_R0.H.get_element();
+    const libff::Fqe<npp> I = check_double_R0.I.get_element();
+    const libff::Fqe<npp> J = check_double_R0.J.get_element();
+    const libff::Fqe<npp> E_squared = check_double_R0.E_squared.get_element();
+    const libff::Fqe<npp> G_squared = check_double_R0.G_squared.get_element();
+    const libff::Fqe<npp> B_minus_F = check_double_R0.B_minus_F.get_element();
+    const libff::Fqe<npp> G_squared_minus_3_E_squared =
         check_double_R0.G_squared_minus_3_E_squared.get_element();
 
-    ASSERT_EQ(R0.X * R0.Y, libff::Fr<ppp>(2) * A);
+    ASSERT_EQ(R0.X * R0.Y, libff::Fr<wpp>(2) * A);
 
     ASSERT_EQ(R0.Y.squared(), B);
 
     ASSERT_EQ(R0.Z.squared(), C);
 
-    ASSERT_EQ(libff::Fr<ppp>(3) * libff::bls12_377_twist_coeff_b * C, E);
+    ASSERT_EQ(libff::Fr<wpp>(3) * libff::bls12_377_twist_coeff_b * C, E);
 
-    ASSERT_EQ(libff::Fr<ppp>(3) * E, F);
+    ASSERT_EQ(libff::Fr<wpp>(3) * E, F);
 
     ASSERT_EQ(two_inv * (B + F), G);
 
-    const libff::Fqe<cpp> Y_plus_Z_squared = (R0.Y + R0.Z).squared();
+    const libff::Fqe<npp> Y_plus_Z_squared = (R0.Y + R0.Z).squared();
     ASSERT_EQ(Y_plus_Z_squared - B - C, H);
 
     ASSERT_EQ(E - B, I);
@@ -104,7 +102,7 @@ TEST(BLS12_377_PairingTest, PrecomputeDoubleGadgetTest)
     ASSERT_EQ(R1.X, R1_var.X.get_element());
 
     ASSERT_EQ(
-        G_squared - (libff::Fr<ppp>(3) * E_squared),
+        G_squared - (libff::Fr<wpp>(3) * E_squared),
         G_squared_minus_3_E_squared);
     ASSERT_EQ(G_squared_minus_3_E_squared, R1_var.Y.get_element());
     ASSERT_EQ(R1.Y, R1_var.Y.get_element());
@@ -119,9 +117,9 @@ TEST(BLS12_377_PairingTest, PrecomputeDoubleGadgetTest)
 
     // Generate and check the proof
     const typename snark::KeypairT keypair = snark::generate_setup(pb);
-    libsnark::r1cs_primary_input<libff::Fr<ppp>> primary_input =
+    libsnark::r1cs_primary_input<libff::Fr<wpp>> primary_input =
         pb.primary_input();
-    libsnark::r1cs_auxiliary_input<libff::Fr<ppp>> auxiliary_input =
+    libsnark::r1cs_auxiliary_input<libff::Fr<wpp>> auxiliary_input =
         pb.auxiliary_input();
     typename snark::ProofT proof = snark::generate_proof(pb, keypair.pk);
     ASSERT_TRUE(snark::verify(primary_input, proof, keypair.vk));
@@ -146,17 +144,17 @@ TEST(BLS12_377_PairingTest, PrecomputeAddGadgetTest)
     // Create and populate protoboard with a simple circuit containing the ate
     // add gadget.
 
-    libsnark::protoboard<libff::Fr<ppp>> pb;
-    libsnark::Fqe_variable<ppp> Q_X(pb, " Q_X");
-    libsnark::Fqe_variable<ppp> Q_Y(pb, " Q_Y");
+    libsnark::protoboard<libff::Fr<wpp>> pb;
+    libsnark::Fqe_variable<wpp> Q_X(pb, " Q_X");
+    libsnark::Fqe_variable<wpp> Q_Y(pb, " Q_Y");
     const size_t num_primary_inputs = pb.num_inputs();
-    libzecale::bls12_377_G2_proj<ppp> R0_var(pb, " R0");
+    libzecale::bls12_377_G2_proj<wpp> R0_var(pb, " R0");
 
     pb.set_input_sizes(num_primary_inputs);
     std::cout << "num_primary_inputs: " << std::to_string(num_primary_inputs)
               << "\n";
 
-    libzecale::bls12_377_ate_add_gadget<ppp> check_add_R0(
+    libzecale::bls12_377_ate_add_gadget<wpp> check_add_R0(
         pb, Q_X, Q_Y, R0_var, "check R1");
 
     check_add_R0.generate_r1cs_constraints();
@@ -171,20 +169,20 @@ TEST(BLS12_377_PairingTest, PrecomputeAddGadgetTest)
 
     // Check values
 
-    const libff::Fqe<cpp> A = check_add_R0.A.get_element();
-    const libff::Fqe<cpp> B = check_add_R0.B.get_element();
-    const libff::Fqe<cpp> theta = check_add_R0.theta.get_element();
-    const libff::Fqe<cpp> lambda = check_add_R0.lambda.get_element();
-    const libff::Fqe<cpp> C = check_add_R0.C.get_element();
-    const libff::Fqe<cpp> D = check_add_R0.D.get_element();
-    const libff::Fqe<cpp> E = check_add_R0.E.get_element();
-    const libff::Fqe<cpp> F = check_add_R0.F.get_element();
-    const libff::Fqe<cpp> G = check_add_R0.G.get_element();
-    const libff::Fqe<cpp> H = check_add_R0.H.get_element();
-    const libff::Fqe<cpp> I = check_add_R0.I.get_element();
-    const libff::Fqe<cpp> J = check_add_R0.J.get_element();
-    const libff::Fqe<cpp> out_Rx = check_add_R0.out_Rx.get_element();
-    const libff::Fqe<cpp> out_Rz = check_add_R0.out_Rz.get_element();
+    const libff::Fqe<npp> A = check_add_R0.A.get_element();
+    const libff::Fqe<npp> B = check_add_R0.B.get_element();
+    const libff::Fqe<npp> theta = check_add_R0.theta.get_element();
+    const libff::Fqe<npp> lambda = check_add_R0.lambda.get_element();
+    const libff::Fqe<npp> C = check_add_R0.C.get_element();
+    const libff::Fqe<npp> D = check_add_R0.D.get_element();
+    const libff::Fqe<npp> E = check_add_R0.E.get_element();
+    const libff::Fqe<npp> F = check_add_R0.F.get_element();
+    const libff::Fqe<npp> G = check_add_R0.G.get_element();
+    const libff::Fqe<npp> H = check_add_R0.H.get_element();
+    const libff::Fqe<npp> I = check_add_R0.I.get_element();
+    const libff::Fqe<npp> J = check_add_R0.J.get_element();
+    const libff::Fqe<npp> out_Rx = check_add_R0.out_Rx.get_element();
+    const libff::Fqe<npp> out_Rz = check_add_R0.out_Rz.get_element();
 
     // A = Qy * Rz
     ASSERT_EQ(Q.Y * R0.Z, A);
@@ -227,9 +225,9 @@ TEST(BLS12_377_PairingTest, PrecomputeAddGadgetTest)
     // Generate and check the proof
 
     const typename snark::KeypairT keypair = snark::generate_setup(pb);
-    libsnark::r1cs_primary_input<libff::Fr<ppp>> primary_input =
+    libsnark::r1cs_primary_input<libff::Fr<wpp>> primary_input =
         pb.primary_input();
-    libsnark::r1cs_auxiliary_input<libff::Fr<ppp>> auxiliary_input =
+    libsnark::r1cs_auxiliary_input<libff::Fr<wpp>> auxiliary_input =
         pb.auxiliary_input();
     typename snark::ProofT proof = snark::generate_proof(pb, keypair.pk);
     ASSERT_TRUE(snark::verify(primary_input, proof, keypair.vk));
@@ -261,12 +259,12 @@ TEST(BLS12_377_PairingTest, PrecomputeGadgetTest)
         libff::bls12_377_ate_precompute_G2(Q);
 
     // Circuit with precompute gadget
-    libsnark::protoboard<libff::Fr<ppp>> pb;
-    libsnark::Fqe_variable<ppp> Qx(pb, " Qx");
-    libsnark::Fqe_variable<ppp> Qy(pb, " Qy");
+    libsnark::protoboard<libff::Fr<wpp>> pb;
+    libsnark::Fqe_variable<wpp> Qx(pb, " Qx");
+    libsnark::Fqe_variable<wpp> Qy(pb, " Qy");
     const size_t num_primary_inputs = pb.num_inputs();
     pb.set_input_sizes(num_primary_inputs);
-    libzecale::bls12_377_ate_precompute_gadget<ppp> precompute_gadget(
+    libzecale::bls12_377_ate_precompute_gadget<wpp> precompute_gadget(
         pb, Qx, Qy, "bls12_317 precompute gadget");
 
     precompute_gadget.generate_r1cs_constraints();
@@ -304,9 +302,9 @@ TEST(BLS12_377_PairingTest, PrecomputeGadgetTest)
 
     // Generate and check the proof
     const typename snark::KeypairT keypair = snark::generate_setup(pb);
-    libsnark::r1cs_primary_input<libff::Fr<ppp>> primary_input =
+    libsnark::r1cs_primary_input<libff::Fr<wpp>> primary_input =
         pb.primary_input();
-    libsnark::r1cs_auxiliary_input<libff::Fr<ppp>> auxiliary_input =
+    libsnark::r1cs_auxiliary_input<libff::Fr<wpp>> auxiliary_input =
         pb.auxiliary_input();
     typename snark::ProofT proof = snark::generate_proof(pb, keypair.pk);
     ASSERT_TRUE(snark::verify(primary_input, proof, keypair.vk));
@@ -330,17 +328,17 @@ TEST(BLS12_377_PairingTest, MillerLoopGadgetTest)
     }
 
     // Circuit with Miller loop gadget
-    libsnark::protoboard<libff::Fr<ppp>> pb;
-    libsnark::pb_variable<libff::Fr<ppp>> Px;
+    libsnark::protoboard<libff::Fr<wpp>> pb;
+    libsnark::pb_variable<libff::Fr<wpp>> Px;
     Px.allocate(pb, "Px");
-    libsnark::pb_variable<libff::Fr<ppp>> Py;
+    libsnark::pb_variable<libff::Fr<wpp>> Py;
     Py.allocate(pb, "Py");
-    libsnark::Fqe_variable<ppp> Qx(pb, " Qx");
-    libsnark::Fqe_variable<ppp> Qy(pb, " Qy");
+    libsnark::Fqe_variable<wpp> Qx(pb, " Qx");
+    libsnark::Fqe_variable<wpp> Qy(pb, " Qy");
     const size_t num_primary_inputs = pb.num_inputs();
     pb.set_input_sizes(num_primary_inputs);
 
-    libzecale::bls12_377_ate_miller_loop_gadget<ppp> miller_loop_gadget(
+    libzecale::bls12_377_ate_miller_loop_gadget<wpp> miller_loop_gadget(
         pb, Px, Py, Qx, Qy, "miller loop");
 
     miller_loop_gadget.generate_r1cs_constraints();
@@ -362,9 +360,9 @@ TEST(BLS12_377_PairingTest, MillerLoopGadgetTest)
 
     // Generate and check the proof
     const typename snark::KeypairT keypair = snark::generate_setup(pb);
-    libsnark::r1cs_primary_input<libff::Fr<ppp>> primary_input =
+    libsnark::r1cs_primary_input<libff::Fr<wpp>> primary_input =
         pb.primary_input();
-    libsnark::r1cs_auxiliary_input<libff::Fr<ppp>> auxiliary_input =
+    libsnark::r1cs_auxiliary_input<libff::Fr<wpp>> auxiliary_input =
         pb.auxiliary_input();
     typename snark::ProofT proof = snark::generate_proof(pb, keypair.pk);
     ASSERT_TRUE(snark::verify(primary_input, proof, keypair.vk));

--- a/libzecale/tests/circuits/bls12_377_pairing_test.cpp
+++ b/libzecale/tests/circuits/bls12_377_pairing_test.cpp
@@ -1,0 +1,143 @@
+// Copyright (c) 2015-2020 Clearmatics Technologies Ltd
+//
+// SPDX-License-Identifier: LGPL-3.0+
+
+#include "libzecale/circuits/pairing/bls12_377_pairing.hpp"
+#include "libzecale/circuits/pairing/bw6_761_pairing_params.hpp"
+
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+
+#include <gtest/gtest.h>
+#include <libff/algebra/curves/bls12_377/bls12_377_pp.hpp>
+#include <libff/algebra/curves/bw6_761/bw6_761_pp.hpp>
+#include <libsnark/gadgetlib1/gadgets/fields/fp2_gadgets.hpp>
+#include <libsnark/gadgetlib1/gadgets/pairing/pairing_params.hpp>
+#include <libzeth/snarks/groth16/groth16_snark.hpp>
+
+using ppp = libff::bw6_761_pp; // Parent pairing
+using ps = libsnark::pairing_selector<ppp>;
+using cpp = ps::other_curve_type; // Child pairing
+
+using snark = libzeth::groth16_snark<ppp>;
+
+namespace
+{
+
+TEST(BLS12_377_PairingTest, PrecomputeDoubleGadgetTest)
+{
+    // Fqe element in bls12-377.  Perform a single double step natively.
+    const libff::bls12_377_G2 R0 =
+        libff::bls12_377_Fr("13") * libff::bls12_377_G2::one();
+    const libff::bls12_377_Fq two_inv = libff::bls12_377_Fq("2").inverse();
+
+    libff::bls12_377_ate_ell_coeffs R1_coeffs;
+    libff::bls12_377_G2 R1;
+    {
+        R1 = R0;
+        libff::bls12_377_doubling_step_for_miller_loop(two_inv, R1, R1_coeffs);
+    }
+
+    // Create and populate protoboard
+
+    libsnark::protoboard<libff::Fr<ppp>> pb;
+
+    libzecale::bls12_377_G2_proj<ppp> R0_var(pb, "R0");
+
+    const size_t num_primary_inputs = pb.num_inputs();
+    pb.set_input_sizes(num_primary_inputs);
+    std::cout << "num_primary_inputs: " << std::to_string(num_primary_inputs)
+              << "\n";
+
+    libzecale::bls12_377_ate_dbl_gadget<ppp> check_double_R0(
+        pb, R0_var, "check R1");
+
+    check_double_R0.generate_r1cs_constraints();
+
+    // Populate the values
+
+    R0_var.generate_r1cs_witness(R0);
+    check_double_R0.generate_r1cs_witness(two_inv);
+
+    // Check values
+
+    const libzecale::bls12_377_G2_proj<ppp> &R1_var = check_double_R0.out_R;
+    const libzecale::bls12_377_ate_ell_coeffs<ppp> &R1_coeffs_var =
+        check_double_R0.out_coeffs;
+
+    const libff::Fqe<cpp> A = check_double_R0.A.get_element();
+    const libff::Fqe<cpp> B = check_double_R0.B.get_element();
+    const libff::Fqe<cpp> C = check_double_R0.C.get_element();
+    const libff::Fqe<cpp> E = check_double_R0.E.get_element();
+    const libff::Fqe<cpp> F = check_double_R0.F.get_element();
+    const libff::Fqe<cpp> G = check_double_R0.G.get_element();
+    const libff::Fqe<cpp> H = check_double_R0.H.get_element();
+    const libff::Fqe<cpp> I = check_double_R0.I.get_element();
+    const libff::Fqe<cpp> J = check_double_R0.J.get_element();
+    const libff::Fqe<cpp> E_squared = check_double_R0.E_squared.get_element();
+    const libff::Fqe<cpp> G_squared = check_double_R0.G_squared.get_element();
+    const libff::Fqe<cpp> B_minus_F = check_double_R0.B_minus_F.get_element();
+    const libff::Fqe<cpp> G_squared_minus_3_E_squared =
+        check_double_R0.G_squared_minus_3_E_squared.get_element();
+
+    ASSERT_EQ(R0.X * R0.Y, libff::Fr<ppp>(2) * A);
+
+    ASSERT_EQ(R0.Y.squared(), B);
+
+    ASSERT_EQ(R0.Z.squared(), C);
+
+    ASSERT_EQ(libff::Fr<ppp>(3) * libff::bls12_377_twist_coeff_b * C, E);
+
+    ASSERT_EQ(libff::Fr<ppp>(3) * E, F);
+
+    ASSERT_EQ(two_inv * (B + F), G);
+
+    const libff::Fqe<cpp> Y_plus_Z_squared = (R0.Y + R0.Z).squared();
+    ASSERT_EQ(Y_plus_Z_squared - B - C, H);
+
+    ASSERT_EQ(E - B, I);
+
+    ASSERT_EQ(R0.X.squared(), J);
+
+    ASSERT_EQ(E.squared(), E_squared);
+    ASSERT_EQ(G.squared(), G_squared);
+    ASSERT_EQ(B - F, B_minus_F);
+
+    ASSERT_EQ(A * (B - F), R1_var.X.get_element());
+    ASSERT_EQ(R1.X, R1_var.X.get_element());
+
+    ASSERT_EQ(
+        G_squared - (libff::Fr<ppp>(3) * E_squared),
+        G_squared_minus_3_E_squared);
+    ASSERT_EQ(G_squared_minus_3_E_squared, R1_var.Y.get_element());
+    ASSERT_EQ(R1.Y, R1_var.Y.get_element());
+
+    ASSERT_EQ(R1.Z, R1_var.Z.get_element());
+
+    ASSERT_EQ(R1_coeffs.ell_0, R1_coeffs_var.ell_0.get_element());
+
+    ASSERT_EQ(R1_coeffs.ell_VW, R1_coeffs_var.ell_vw.get_element());
+
+    ASSERT_EQ(R1_coeffs.ell_VV, R1_coeffs_var.ell_vv.get_element());
+
+    // Generate and check the proof
+
+    const typename snark::KeypairT keypair = snark::generate_setup(pb);
+    libsnark::r1cs_primary_input<libff::Fr<ppp>> primary_input =
+        pb.primary_input();
+    libsnark::r1cs_auxiliary_input<libff::Fr<ppp>> auxiliary_input =
+        pb.auxiliary_input();
+    typename snark::ProofT proof = snark::generate_proof(pb, keypair.pk);
+    ASSERT_TRUE(snark::verify(primary_input, proof, keypair.vk));
+}
+
+} // namespace
+
+int main(int argc, char **argv)
+{
+    libff::bls12_377_pp::init_public_params();
+    libff::bw6_761_pp::init_public_params();
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/libzecale/tests/circuits/bls12_377_pairing_test.cpp
+++ b/libzecale/tests/circuits/bls12_377_pairing_test.cpp
@@ -154,9 +154,9 @@ TEST(BLS12_377_PairingTest, PrecomputeAddGadgetTest)
     libsnark::protoboard<libff::Fr<ppp>> pb;
     libsnark::Fqe_variable<ppp> Q_X(pb, " Q_X");
     libsnark::Fqe_variable<ppp> Q_Y(pb, " Q_Y");
+    const size_t num_primary_inputs = pb.num_inputs();
     libzecale::bls12_377_G2_proj<ppp> R0_var(pb, " R0");
 
-    const size_t num_primary_inputs = pb.num_inputs();
     pb.set_input_sizes(num_primary_inputs);
     std::cout << "num_primary_inputs: " << std::to_string(num_primary_inputs)
               << "\n";
@@ -187,15 +187,8 @@ TEST(BLS12_377_PairingTest, PrecomputeAddGadgetTest)
     const libff::Fqe<cpp> G = check_add_R0.G.get_element();
     const libff::Fqe<cpp> H = check_add_R0.H.get_element();
     const libff::Fqe<cpp> I = check_add_R0.I.get_element();
-    const libff::Fqe<cpp> theta_times_Qx =
-        check_add_R0.theta_times_Qx.get_element();
-    const libff::Fqe<cpp> lambda_times_Qy =
-        check_add_R0.lambda_times_Qy.get_element();
     const libff::Fqe<cpp> J = check_add_R0.J.get_element();
     const libff::Fqe<cpp> out_Rx = check_add_R0.out_Rx.get_element();
-    const libff::Fqe<cpp> G_minus_H = check_add_R0.G_minus_H.get_element();
-    const libff::Fqe<cpp> theta_times_G_minus_H =
-        check_add_R0.theta_times_G_minus_H.get_element();
     const libff::Fqe<cpp> out_Rz = check_add_R0.out_Rz.get_element();
 
     // A = Qy * Rz
@@ -222,20 +215,9 @@ TEST(BLS12_377_PairingTest, PrecomputeAddGadgetTest)
     ASSERT_EQ(R0.Y * E, I);
     // J = theta * Qx - lambda * Qy;
     ASSERT_EQ(theta * Q.X - lambda * Q.Y, J);
-    // libsnark::Fqe_variable<ppT> theta_times_Rx;
-    // libsnark::Fqe_mul_gadget<ppT> check_theta_times_Rx;
-    // libsnark::Fqe_variable<ppT> lambda_times_Ry;
-    // libsnark::Fqe_mul_gadget<ppT> check_lambda_times_Ry;
-    // libsnark::Fqe_variable<ppT> J;
 
     // out_Rx = lambda * H;
     ASSERT_EQ(lambda * H, out_Rx);
-    // // out_Ry = theta * (G - H) - I;
-    // libsnark::Fqe_variable<ppT> G_minus_H;
-    // libsnark::Fqe_variable<ppT> theta_times_G_minus_H;
-    // libsnark::Fqe_mul_gadget<ppT> check_theta_times_G_minus_H;
-    // // out_Rz = Z1 * E;
-    // libsnark::Fqe_variable<ppT> out_Rz;
 
     ASSERT_EQ(R1.X, out_Rx);
     ASSERT_EQ(R1.Z, out_Rz);

--- a/libzecale/tests/circuits/bls12_377_pairing_test.cpp
+++ b/libzecale/tests/circuits/bls12_377_pairing_test.cpp
@@ -161,7 +161,7 @@ TEST(BLS12_377_PairingTest, PrecomputeAddGadgetTest)
 
     check_add_R0.generate_r1cs_constraints();
 
-    // Populate R0 and Q, and generate values vai the gadget
+    // Populate R0 and Q, and generate values via the gadget
 
     Q_X.generate_r1cs_witness(Q.X);
     Q_Y.generate_r1cs_witness(Q.Y);

--- a/libzecale/tests/circuits/fp12_2over3over2_gadgets_test.cpp
+++ b/libzecale/tests/circuits/fp12_2over3over2_gadgets_test.cpp
@@ -1,0 +1,180 @@
+// Copyright (c) 2015-2020 Clearmatics Technologies Ltd
+//
+// SPDX-License-Identifier: LGPL-3.0+
+
+#include "libzecale/circuits/fields/fp12_2over3over2_gadgets.hpp"
+#include "libzecale/circuits/pairing/bls12_377_pairing.hpp"
+#include "libzecale/circuits/pairing/bw6_761_pairing_params.hpp"
+
+#include <gtest/gtest.h>
+#include <libff/algebra/curves/bls12_377/bls12_377_pp.hpp>
+#include <libff/algebra/curves/bw6_761/bw6_761_pp.hpp>
+#include <libzeth/snarks/groth16/groth16_snark.hpp>
+
+using ppp = libff::bw6_761_pp;
+using snark = libzeth::groth16_snark<ppp>;
+
+namespace
+{
+
+TEST(Fp12_2over3over2_Test, SquareGadgetTest)
+{
+    using Fp12T = libff::bls12_377_Fq12;
+    using FieldT = typename Fp12T::my_Fp;
+    using Fp2T = typename Fp12T::my_Fp2;
+    using Fp6T = typename Fp12T::my_Fp6;
+
+    // Native squaring
+    const Fp12T z(
+        Fp6T(
+            Fp2T(FieldT("5"), FieldT("6")),
+            Fp2T(FieldT("7"), FieldT("8")),
+            Fp2T(FieldT("9"), FieldT("10"))),
+        Fp6T(
+            Fp2T(FieldT("21"), FieldT("22")),
+            Fp2T(FieldT("23"), FieldT("24")),
+            Fp2T(FieldT("25"), FieldT("26"))));
+    const Fp12T z_squared = z.squared();
+
+    // Squaring in a circuit
+    libsnark::protoboard<FieldT> pb;
+    libzecale::Fp12_2over3over2_variable<Fp12T> z_var(pb, "z");
+    libzecale::Fp12_2over3over2_variable<Fp12T> z_squared_var(pb, "z");
+    const size_t num_primary_inputs = pb.num_inputs();
+    pb.set_input_sizes(num_primary_inputs);
+
+    libzecale::Fp12_2over3over2_square_gadget<Fp12T> square_gadget(
+        pb, z_var, z_squared_var, "square z");
+
+    // Constraints
+    square_gadget.generate_r1cs_constraints();
+
+    // Values
+    z_var.generate_r1cs_witness(z);
+    square_gadget.generate_r1cs_witness();
+
+    const Fp12T z_squared_val = z_squared_var.get_element();
+    ASSERT_EQ(z_squared, z_squared_val);
+
+    // Generate and check the proof
+    const typename snark::KeypairT keypair = snark::generate_setup(pb);
+    libsnark::r1cs_primary_input<libff::Fr<ppp>> primary_input =
+        pb.primary_input();
+    libsnark::r1cs_auxiliary_input<libff::Fr<ppp>> auxiliary_input =
+        pb.auxiliary_input();
+    typename snark::ProofT proof = snark::generate_proof(pb, keypair.pk);
+    ASSERT_TRUE(snark::verify(primary_input, proof, keypair.vk));
+}
+
+TEST(Fp12_2over3over2_Test, MulBy024GadgetTest)
+{
+    using Fp12T = libff::bls12_377_Fq12;
+    using FieldT = typename Fp12T::my_Fp;
+    using Fp2T = typename Fp12T::my_Fp2;
+    using Fp6T = typename Fp12T::my_Fp6;
+
+    // Native multiplication, using values from the libff tests.
+    const Fp12T z(
+        Fp6T(
+            Fp2T(FieldT("5"), FieldT("6")),
+            Fp2T(FieldT("7"), FieldT("8")),
+            Fp2T(FieldT("9"), FieldT("10"))),
+        Fp6T(
+            Fp2T(FieldT("21"), FieldT("22")),
+            Fp2T(FieldT("23"), FieldT("24")),
+            Fp2T(FieldT("25"), FieldT("26"))));
+    const Fp2T x0(FieldT("11"), FieldT("12"));
+    const Fp2T x2(FieldT("15"), FieldT("16"));
+    const Fp2T x4(FieldT("3"), FieldT("4"));
+    const Fp12T z_times_x = z.mul_by_024(x0, x4, x2);
+
+    // Multiplication in a circuit
+    libsnark::protoboard<FieldT> pb;
+    libzecale::Fp12_2over3over2_variable<Fp12T> z_var(pb, "z");
+    libsnark::Fp2_variable<Fp2T> x0_var(pb, " x0");
+    libsnark::Fp2_variable<Fp2T> x2_var(pb, " x2");
+    libsnark::Fp2_variable<Fp2T> x4_var(pb, " x4");
+    libzecale::Fp12_2over3over2_variable<Fp12T> z_times_x_var(pb, "z_times_x");
+    const size_t num_primary_inputs = pb.num_inputs();
+    pb.set_input_sizes(num_primary_inputs);
+
+    libzecale::Fp12_2over3over2_mul_by_024_gadget<Fp12T> mul_024(
+        pb, z_var, x0_var, x2_var, x4_var, z_times_x_var, "mul_024");
+
+    // Constraints
+    mul_024.generate_r1cs_constraints();
+
+    // Values
+    z_var.generate_r1cs_witness(z);
+    x0_var.generate_r1cs_witness(x0);
+    x2_var.generate_r1cs_witness(x2);
+    x4_var.generate_r1cs_witness(x4);
+    mul_024.generate_r1cs_witness();
+
+    const Fp2T &z0 = z.c0.c0;
+    const Fp2T &z1 = z.c0.c1;
+    const Fp2T &z2 = z.c0.c2;
+    const Fp2T &z3 = z.c1.c0;
+    const Fp2T &z4 = z.c1.c1;
+    const Fp2T &z5 = z.c1.c2;
+    ASSERT_EQ(z, mul_024._Z.get_element());
+    ASSERT_EQ(x0, mul_024._X_0.get_element());
+    ASSERT_EQ(x2, mul_024._X_2.get_element());
+    ASSERT_EQ(x4, mul_024._X_4.get_element());
+
+    const Fp12T z_times_x_val = z_times_x_var.get_element();
+    ASSERT_EQ(z_times_x_val, mul_024._result.get_element());
+
+    // result.c0.c0
+    ASSERT_EQ(z1 * x2, mul_024._z1_x2.result.get_element());
+    ASSERT_EQ(z4 * x4, mul_024._z4_x4.result.get_element());
+    ASSERT_EQ(z0 * x0, mul_024._z0_x0.result.get_element());
+    ASSERT_EQ(z_times_x.c0.c0, z_times_x_val.c0.c0);
+
+    // result.c0.c1
+    ASSERT_EQ(z2 * x2, mul_024._z2_x2.result.get_element());
+    ASSERT_EQ(z5 * x4, mul_024._z5_x4.result.get_element());
+    ASSERT_EQ(z_times_x.c0.c1, z_times_x_val.c0.c1);
+
+    // result.c0.c2
+    ASSERT_EQ(z3 * x4, mul_024._z3_x4.result.get_element());
+    ASSERT_EQ(z_times_x.c0.c2, z_times_x_val.c0.c2);
+
+    // result.c1.c0
+    ASSERT_EQ(z3 * x0, mul_024._z3_x0.result.get_element());
+    ASSERT_EQ(z_times_x.c1.c0, z_times_x_val.c1.c0);
+
+    // result.c1.c1
+    ASSERT_EQ(z5 * x2, mul_024._z5_x2.result.get_element());
+    ASSERT_EQ(z_times_x.c1.c1, z_times_x_val.c1.c1);
+
+    // result.c1.c2
+    ASSERT_EQ(z1 * x0, mul_024._z1_x0.result.get_element());
+    const Fp2T S =
+        (z1 * x2) + (z1 * x0) + (z5 * x4) + (z3 * x4) + (z3 * x0) + (z5 * x2);
+    ASSERT_EQ(S, mul_024._S.get_element());
+    ASSERT_EQ((z1 + z3 + z5) * (x0 + x2 + x4) - S, z_times_x_val.c1.c2);
+    ASSERT_EQ(z_times_x.c1.c2, z_times_x_val.c1.c2);
+
+    // result
+    ASSERT_EQ(z_times_x, z_times_x_var.get_element());
+
+    // Generate and check the proof
+    const typename snark::KeypairT keypair = snark::generate_setup(pb);
+    libsnark::r1cs_primary_input<libff::Fr<ppp>> primary_input =
+        pb.primary_input();
+    libsnark::r1cs_auxiliary_input<libff::Fr<ppp>> auxiliary_input =
+        pb.auxiliary_input();
+    typename snark::ProofT proof = snark::generate_proof(pb, keypair.pk);
+    ASSERT_TRUE(snark::verify(primary_input, proof, keypair.vk));
+}
+
+} // namespace
+
+int main(int argc, char **argv)
+{
+    libff::bls12_377_pp::init_public_params();
+    libff::bw6_761_pp::init_public_params();
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/libzecale/tests/circuits/fp12_2over3over2_gadgets_test.cpp
+++ b/libzecale/tests/circuits/fp12_2over3over2_gadgets_test.cpp
@@ -39,12 +39,12 @@ TEST(Fp12_2over3over2_Test, SquareGadgetTest)
     // Squaring in a circuit
     libsnark::protoboard<FieldT> pb;
     libzecale::Fp12_2over3over2_variable<Fp12T> z_var(pb, "z");
-    libzecale::Fp12_2over3over2_variable<Fp12T> z_squared_var(pb, "z");
+    libzecale::Fp12_2over3over2_variable<Fp12T> z_squared_var(pb, "z_squared");
     const size_t num_primary_inputs = pb.num_inputs();
     pb.set_input_sizes(num_primary_inputs);
 
     libzecale::Fp12_2over3over2_square_gadget<Fp12T> square_gadget(
-        pb, z_var, z_squared_var, "square z");
+        pb, z_var, z_squared_var, " square_z");
 
     // Constraints
     square_gadget.generate_r1cs_constraints();

--- a/libzecale/tests/circuits/fp6_3over2_gadgets_test.cpp
+++ b/libzecale/tests/circuits/fp6_3over2_gadgets_test.cpp
@@ -71,7 +71,6 @@ TEST(Fp6_3over2_Test, MulGadgetTest)
     ASSERT_EQ(a.c0 * b.c0, a0b0);
     ASSERT_EQ((a.c0 + a.c1) * (b.c0 + b.c1), a0a1_times_b0b1);
     ASSERT_EQ((a.c0 + a.c2) * (b.c0 + b.c2), a0a2_times_b0b2);
-    // ASSERT_EQ(c.c0, c_val.c0);
     ASSERT_EQ(c.c1, c_val.c1);
     ASSERT_EQ(c.c2, c_val.c2);
     ASSERT_EQ(c, c_val);

--- a/libzecale/tests/circuits/fp6_3over2_gadgets_test.cpp
+++ b/libzecale/tests/circuits/fp6_3over2_gadgets_test.cpp
@@ -55,10 +55,10 @@ TEST(Fp6_3over2_Test, MulGadgetTest)
     // Check values
     const Fp6T a_val = a_var.get_element();
     const Fp6T b_val = b_var.get_element();
-    const Fp2T v1 = mul_a_b._v1.result.get_element();
-    const Fp2T v2 = mul_a_b._v2.result.get_element();
+    const Fp2T v1 = mul_a_b._a1_times_b1.result.get_element();
+    const Fp2T v2 = mul_a_b._a2_times_b2.result.get_element();
     const Fp2T a1a2_times_b1b2 = mul_a_b._a1a2_times_b1b2.result.get_element();
-    const Fp2T v0 = mul_a_b._v0.result.get_element();
+    const Fp2T v0 = mul_a_b._a0_times_b0.result.get_element();
     const Fp2T a0a1_times_b0b1 = mul_a_b._a0a1_times_b0b1.result.get_element();
     const Fp2T a0a2_times_b0b2 = mul_a_b._a0a2_times_b0b2.result.get_element();
     const Fp6T c_val = c_var.get_element();

--- a/libzecale/tests/circuits/fp6_3over2_gadgets_test.cpp
+++ b/libzecale/tests/circuits/fp6_3over2_gadgets_test.cpp
@@ -55,20 +55,20 @@ TEST(Fp6_3over2_Test, MulGadgetTest)
     // Check values
     const Fp6T a_val = a_var.get_element();
     const Fp6T b_val = b_var.get_element();
-    const Fp2T a1b1 = mul_a_b._a1b1.result.get_element();
-    const Fp2T a2b2 = mul_a_b._a2b2.result.get_element();
+    const Fp2T v1 = mul_a_b._v1.result.get_element();
+    const Fp2T v2 = mul_a_b._v2.result.get_element();
     const Fp2T a1a2_times_b1b2 = mul_a_b._a1a2_times_b1b2.result.get_element();
-    const Fp2T a0b0 = mul_a_b._a0b0.result.get_element();
+    const Fp2T v0 = mul_a_b._v0.result.get_element();
     const Fp2T a0a1_times_b0b1 = mul_a_b._a0a1_times_b0b1.result.get_element();
     const Fp2T a0a2_times_b0b2 = mul_a_b._a0a2_times_b0b2.result.get_element();
     const Fp6T c_val = c_var.get_element();
 
     ASSERT_EQ(a, a_val);
     ASSERT_EQ(b, b_val);
-    ASSERT_EQ(a.c1 * b.c1, a1b1);
-    ASSERT_EQ(a.c2 * b.c2, a2b2);
+    ASSERT_EQ(a.c1 * b.c1, v1);
+    ASSERT_EQ(a.c2 * b.c2, v2);
     ASSERT_EQ((a.c1 + a.c2) * (b.c1 + b.c2), a1a2_times_b1b2);
-    ASSERT_EQ(a.c0 * b.c0, a0b0);
+    ASSERT_EQ(a.c0 * b.c0, v0);
     ASSERT_EQ((a.c0 + a.c1) * (b.c0 + b.c1), a0a1_times_b0b1);
     ASSERT_EQ((a.c0 + a.c2) * (b.c0 + b.c2), a0a2_times_b0b2);
     ASSERT_EQ(c.c1, c_val.c1);

--- a/libzecale/tests/circuits/fp6_3over2_gadgets_test.cpp
+++ b/libzecale/tests/circuits/fp6_3over2_gadgets_test.cpp
@@ -1,0 +1,97 @@
+// Copyright (c) 2015-2020 Clearmatics Technologies Ltd
+//
+// SPDX-License-Identifier: LGPL-3.0+
+
+#include "libzecale/circuits/fields/fp6_3over2_gadgets.hpp"
+// #include "libzecale/circuits/pairing/bw6_761_pairing_params.hpp"
+
+#include <gtest/gtest.h>
+#include <libff/algebra/curves/bls12_377/bls12_377_pp.hpp>
+#include <libff/algebra/curves/bw6_761/bw6_761_pp.hpp>
+#include <libzeth/snarks/groth16/groth16_snark.hpp>
+
+using ppp = libff::bw6_761_pp;
+using snark = libzeth::groth16_snark<ppp>;
+
+namespace
+{
+
+TEST(Fp6_3over2_Test, MulGadgetTest)
+{
+    using Fp6T = libff::bls12_377_Fq6;
+    using Fp2T = typename Fp6T::my_Fp2;
+    using FieldT = typename Fp6T::my_Fp;
+
+    // Native multiplication
+    const Fp6T a(
+        Fp2T(FieldT("5"), FieldT("6")),
+        Fp2T(FieldT("7"), FieldT("8")),
+        Fp2T(FieldT("9"), FieldT("10")));
+    const Fp6T b(
+        Fp2T(FieldT("21"), FieldT("22")),
+        Fp2T(FieldT("23"), FieldT("24")),
+        Fp2T(FieldT("25"), FieldT("26")));
+    const Fp6T c = a * b;
+
+    // Multiplication in circuit
+    libsnark::protoboard<FieldT> pb;
+    libzecale::Fp6_3over2_variable<Fp6T> a_var(pb, "a");
+    libzecale::Fp6_3over2_variable<Fp6T> b_var(pb, "b");
+    libzecale::Fp6_3over2_variable<Fp6T> c_var(pb, "c");
+    const size_t num_primary_inputs = pb.num_inputs();
+    pb.set_input_sizes(num_primary_inputs);
+
+    libzecale::Fp6_3over2_mul_gadget<Fp6T> mul_a_b(
+        pb, a_var, b_var, c_var, "a*b");
+
+    // Constraints
+    mul_a_b.generate_r1cs_constraints();
+
+    // values
+    a_var.generate_r1cs_witness(a);
+    b_var.generate_r1cs_witness(b);
+    mul_a_b.generate_r1cs_witness();
+
+    // Check values
+    const Fp6T a_val = a_var.get_element();
+    const Fp6T b_val = b_var.get_element();
+    const Fp2T a1b1 = mul_a_b._a1b1.result.get_element();
+    const Fp2T a2b2 = mul_a_b._a2b2.result.get_element();
+    const Fp2T a1a2_times_b1b2 = mul_a_b._a1a2_times_b1b2.result.get_element();
+    const Fp2T a0b0 = mul_a_b._a0b0.result.get_element();
+    const Fp2T a0a1_times_b0b1 = mul_a_b._a0a1_times_b0b1.result.get_element();
+    const Fp2T a0a2_times_b0b2 = mul_a_b._a0a2_times_b0b2.result.get_element();
+    const Fp6T c_val = c_var.get_element();
+
+    ASSERT_EQ(a, a_val);
+    ASSERT_EQ(b, b_val);
+    ASSERT_EQ(a.c1 * b.c1, a1b1);
+    ASSERT_EQ(a.c2 * b.c2, a2b2);
+    ASSERT_EQ((a.c1 + a.c2) * (b.c1 + b.c2), a1a2_times_b1b2);
+    ASSERT_EQ(a.c0 * b.c0, a0b0);
+    ASSERT_EQ((a.c0 + a.c1) * (b.c0 + b.c1), a0a1_times_b0b1);
+    ASSERT_EQ((a.c0 + a.c2) * (b.c0 + b.c2), a0a2_times_b0b2);
+    // ASSERT_EQ(c.c0, c_val.c0);
+    ASSERT_EQ(c.c1, c_val.c1);
+    ASSERT_EQ(c.c2, c_val.c2);
+    ASSERT_EQ(c, c_val);
+
+    // Generate and check the proof
+    const typename snark::KeypairT keypair = snark::generate_setup(pb);
+    libsnark::r1cs_primary_input<libff::Fr<ppp>> primary_input =
+        pb.primary_input();
+    libsnark::r1cs_auxiliary_input<libff::Fr<ppp>> auxiliary_input =
+        pb.auxiliary_input();
+    typename snark::ProofT proof = snark::generate_proof(pb, keypair.pk);
+    ASSERT_TRUE(snark::verify(primary_input, proof, keypair.vk));
+}
+
+} // namespace
+
+int main(int argc, char **argv)
+{
+    libff::bls12_377_pp::init_public_params();
+    libff::bw6_761_pp::init_public_params();
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
- pairing parameters for the BW6-761 -> BLS12-377 chain
- initial set of gadgets for field variables and operations (Fp6_3over2 and Fp12_2over3over2)
- pairing precompute and miller loop gadgets
