### PR TITLE
Repo cleanup

### DIFF
--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -1,0 +1,3 @@
+# Coding Standards
+
+Except if stated otherwise, we follow the [Zeth coding standards](https://github.com/clearmatics/zeth/blob/master/CODING_STANDARDS.md).

--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -1,3 +1,11 @@
 # Coding Standards
 
-Except if stated otherwise, we follow the [Zeth coding standards](https://github.com/clearmatics/zeth/blob/master/CODING_STANDARDS.md).
+Unless stated otherwise, we follow the [Zeth coding standards](https://github.com/clearmatics/zeth/blob/master/CODING_STANDARDS.md).
+
+## Naming conventions
+
+- When necessary, type parameters related to the base application and to Zecale are distinguished by using a `n` (for "nested") and a `w` (for "wrapping") prefix. For instance:
+    - `nppT`: Type parameter representing the public parameters defining the nested curve (i.e. the curve over which "nested proofs" are generated. If a pairing-friendly amicable chain is used, `nppT` refers to the first curve of the chain)
+    - `nsnarkT`: Type parameter representing the SNARK scheme used to generate the nested arguments
+    - `wppT`: Type parameter representing the public parameters defining the wrapping curve (i.e. the curve over which the "nested proofs" are verified - and the wrapping proof is generated. If a pairing-friendly amicable chain is used, `wppT` refers to the last curve of the chain)
+    - `wsnarkT`: Type parameter representing the SNARK scheme used to generate the wrapping argument

--- a/README.md
+++ b/README.md
@@ -71,13 +71,6 @@ docker build -f Dockerfile-zecale -t zecale-dev:0.1 .
 docker run -ti -p 50052:50052 --name zecale zecale-dev:0.1
 ```
 
-#### Notes
-
-- `nppT`: Type parameter representing the public parameters defining the nested curve (i.e. the curve over which "nested proofs" are generated. If a pairing-friendly amicable chain is used, `nppT` refers to the first curve of the chain)
-- `nsnarkT`: Type parameter representing the SNARK scheme used to generate the nested arguments
-- `wppT`: Type parameter representing the public parameters defining the wrapping curve (i.e. the curve over which the "nested proofs" are verified - and the wrapping proof is generated. If a pairing-friendly amicable chain is used, `wppT` refers to the last curve of the chain)
-- `wsnarkT`: Type parameter representing the SNARK scheme used to generate the wrapping argument
-
 ## License notices:
 
 ### Libsnark

--- a/debug/README.md
+++ b/debug/README.md
@@ -1,6 +1,6 @@
 # Debug folder
 
-This folder is the default location (pointed by the environment variable `ZETH_DEBUG_DIR`) to write debug data:
+This folder is the default location (pointed by the environment variable `ZECALE_DEBUG_DIR`) to write debug data:
 - Proofs
 - R1CS - Constraints
 and so on.


### PR DESCRIPTION
Fixed erroneous env var name, and added coding standards pointing to the standards in Zeth