### PR TITLE
Subgroup membership check gadgets

### DIFF
--- a/client/.pylintrc
+++ b/client/.pylintrc
@@ -18,7 +18,8 @@ disable=
     broad-except,
     too-many-function-args,
     duplicate-code,
-    fixme
+    fixme,
+    unsubscriptable-object,
 
 good-names=i,e,x,y,m,k,h,c,cm,rc,ek,ex,ct,vk,sk,pk,pp,X,Y,r,el,nf,tx
 

--- a/client/setup.py
+++ b/client/setup.py
@@ -21,15 +21,15 @@ setup(
     packages=find_packages(),
     # zip_safe=False,
     install_requires=[
-        "mypy==0.720",
+        "mypy==0.790",
         "mypy-protobuf==1.23",
         "flake8==3.8.3",
-        "pylint==2.4.3",
+        "pylint==2.6",
         "click==7.0",
         "click-default-group==1.2",
         "protobuf==3.13.0",
-        "grpcio==1.30",
-        "grpcio-tools==1.30",
+        "grpcio==1.33.2",
+        "grpcio-tools==1.33.2",
     ],
     entry_points={
         'console_scripts': [

--- a/client/test_commands/test_bw6_761_groth16_contract.py
+++ b/client/test_commands/test_bw6_761_groth16_contract.py
@@ -22,6 +22,7 @@ DUMMY_APP_DIR = join(ZECALE_DIR, "testdata", "dummy_app")
 # Pairing parameters for BW6-761
 # pylint: disable=line-too-long
 BW6_761_PAIRING_PARAMETERS = PairingParameters.from_json_dict({
+    "name": "bw6-761",
     "r": "0x01ae3a4617c510eac63b05c06ca1493b1a22d9f300f5138f1ef3622fba094800170b5d44300000008508c00000000001",  # noqa
     "q": "0x0122e824fb83ce0ad187c94004faff3eb926186a81d14688528275ef8087be41707ba638e584e91903cebaff25b423048689c8ed12f9fd9071dcd3dc73ebff2e98a116c25667a8f8160cf8aeeaf0a437e6913e6870000082f49d00000000008b",  # noqa
     "generator_g1": [

--- a/client/zecale/api/__init__.py
+++ b/client/zecale/api/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (c) 2015-2020 Clearmatics Technologies Ltd
+# Copyright (c) 2015-2021 Clearmatics Technologies Ltd
 #
 # SPDX-License-Identifier: LGPL-3.0+

--- a/libzecale/circuits/fields/fp12_2over3over2_gadgets.hpp
+++ b/libzecale/circuits/fields/fp12_2over3over2_gadgets.hpp
@@ -40,6 +40,7 @@ public:
         const std::string &annotation_prefix);
 
     Fp12_2over3over2_variable<Fp12T> operator*(const Fp2T &fp2_const) const;
+    Fp12_2over3over2_variable<Fp12T> operator*(const Fp12T &fp12_const) const;
     Fp12_2over3over2_variable<Fp12T> frobenius_map(size_t power) const;
     Fp12_2over3over2_variable<Fp12T> unitary_inverse() const;
     void evaluate() const;

--- a/libzecale/circuits/fields/fp12_2over3over2_gadgets.tcc
+++ b/libzecale/circuits/fields/fp12_2over3over2_gadgets.tcc
@@ -54,6 +54,23 @@ Fp12_2over3over2_variable<Fp12T> Fp12_2over3over2_variable<Fp12T>::operator*(
 }
 
 template<typename Fp12T>
+Fp12_2over3over2_variable<Fp12T> Fp12_2over3over2_variable<Fp12T>::operator*(
+    const Fp12T &fp12_const) const
+{
+    using Fp6_variable = Fp6_3over2_variable<Fp6T>;
+    const Fp6_variable a0_b0 = _c0 * fp12_const.coeffs[0];
+    const Fp6_variable a1_b1 = _c1 * fp12_const.coeffs[1];
+    const Fp6_variable a0a1_b0b1 =
+        (_c0 + _c1) * (fp12_const.coeffs[0] + fp12_const.coeffs[1]);
+
+    return Fp12_2over3over2_variable(
+        this->pb,
+        a0_b0 + (a1_b1 * Fp6T(Fp2T::zero(), Fp2T::one(), Fp2T::zero())),
+        a0a1_b0b1 - a0_b0 - a1_b1,
+        FMT(this->annotation_prefix, " fp12_var*fp12_const"));
+}
+
+template<typename Fp12T>
 Fp12_2over3over2_variable<Fp12T> Fp12_2over3over2_variable<
     Fp12T>::frobenius_map(size_t power) const
 {

--- a/libzecale/circuits/pairing/bls12_377_membership_check_gadgets.hpp
+++ b/libzecale/circuits/pairing/bls12_377_membership_check_gadgets.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2020 Clearmatics Technologies Ltd
+// Copyright (c) 2015-2021 Clearmatics Technologies Ltd
 //
 // SPDX-License-Identifier: LGPL-3.0+
 

--- a/libzecale/circuits/pairing/bls12_377_membership_check_gadgets.hpp
+++ b/libzecale/circuits/pairing/bls12_377_membership_check_gadgets.hpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2015-2020 Clearmatics Technologies Ltd
+//
+// SPDX-License-Identifier: LGPL-3.0+
+
+#ifndef __ZECALE_CIRCUITS_PAIRING_BLS12_377_MEMBERSHIP_CHECK_GADGETS_HPP__
+#define __ZECALE_CIRCUITS_PAIRING_BLS12_377_MEMBERSHIP_CHECK_GADGETS_HPP__
+
+#include "libzecale/circuits/pairing/group_variable_gadgets.hpp"
+#include "libzecale/circuits/pairing/pairing_params.hpp"
+
+#include <libsnark/gadgetlib1/gadgets/curves/weierstrass_g1_gadget.hpp>
+
+namespace libzecale
+{
+
+/// Curve equation and subgroup membership check for BLS12-377 G1 variables.
+template<typename wppT>
+class bls12_377_G1_membership_check_gadget : libsnark::gadget<libff::Fr<wppT>>
+{
+public:
+    using nppT = other_curve<wppT>;
+    using G1_mul_by_cofactor_gadget =
+        G1_mul_by_const_scalar_gadget<wppT, libff::G1<nppT>::h_limbs>;
+
+    // Point P to check
+    libsnark::G1_variable<wppT> _P;
+    // P' s.t. [h]P' = P
+    libsnark::G1_variable<wppT> _P_primed;
+    // Check that P' \in E(Fq)
+    libsnark::G1_checker_gadget<wppT> _P_primed_checker;
+    // [h]P' = P condition
+    G1_mul_by_cofactor_gadget _P_primed_mul_cofactor;
+
+    bls12_377_G1_membership_check_gadget(
+        libsnark::protoboard<libff::Fr<wppT>> &pb,
+        const libsnark::G1_variable<wppT> &P,
+        const std::string &annotation_prefix);
+    void generate_r1cs_constraints();
+    void generate_r1cs_witness();
+};
+
+} // namespace libzecale
+
+#include "libzecale/circuits/pairing/bls12_377_membership_check_gadgets.tcc"
+
+#endif // __ZECALE_CIRCUITS_PAIRING_BLS12_377_MEMBERSHIP_CHECK_GADGETS_HPP__

--- a/libzecale/circuits/pairing/bls12_377_membership_check_gadgets.hpp
+++ b/libzecale/circuits/pairing/bls12_377_membership_check_gadgets.hpp
@@ -5,9 +5,11 @@
 #ifndef __ZECALE_CIRCUITS_PAIRING_BLS12_377_MEMBERSHIP_CHECK_GADGETS_HPP__
 #define __ZECALE_CIRCUITS_PAIRING_BLS12_377_MEMBERSHIP_CHECK_GADGETS_HPP__
 
+#include "libzecale/circuits/fields/fp12_2over3over2_gadgets.hpp"
 #include "libzecale/circuits/pairing/group_variable_gadgets.hpp"
 #include "libzecale/circuits/pairing/pairing_params.hpp"
 
+#include <libff/algebra/curves/bls12_377/bls12_377_init.hpp>
 #include <libsnark/gadgetlib1/gadgets/curves/weierstrass_g1_gadget.hpp>
 
 namespace libzecale
@@ -38,6 +40,16 @@ public:
     void generate_r1cs_constraints();
     void generate_r1cs_witness();
 };
+
+/// Untwist-Frobenius-Twist operation on BLS12-377 G2 elements. (Note that
+/// evaluate should be called on the result, or its components, before using it
+/// in witness generation).
+template<typename wppT>
+libsnark::G2_variable<wppT> bls12_377_g2_untwist_frobenius_twist(
+    libsnark::protoboard<libff::Fr<wppT>> &pb,
+    const libsnark::G2_variable<wppT> &g2,
+    size_t exp,
+    const std::string &annotation_prefix);
 
 } // namespace libzecale
 

--- a/libzecale/circuits/pairing/bls12_377_membership_check_gadgets.hpp
+++ b/libzecale/circuits/pairing/bls12_377_membership_check_gadgets.hpp
@@ -11,6 +11,7 @@
 
 #include <libff/algebra/curves/bls12_377/bls12_377_init.hpp>
 #include <libsnark/gadgetlib1/gadgets/curves/weierstrass_g1_gadget.hpp>
+#include <libsnark/gadgetlib1/gadgets/curves/weierstrass_g2_gadget.hpp>
 
 namespace libzecale
 {
@@ -50,6 +51,41 @@ libsnark::G2_variable<wppT> bls12_377_g2_untwist_frobenius_twist(
     const libsnark::G2_variable<wppT> &g2,
     size_t exp,
     const std::string &annotation_prefix);
+
+/// Curve equation and subgroup membership check for BLS12-377 G2 variables.
+template<typename wppT>
+class bls12_377_G2_membership_check_gadget : libsnark::gadget<libff::Fr<wppT>>
+{
+public:
+    // Follows libff implementation of bls12_377_G2::is_in_safe_subgroup().
+    // See: libff/algebra/curves/bls12_377/bls12_377_g2.cpp.
+
+    // Check that[h1.r] P == 0, where
+    //   [h1.r]P is P + [t](\psi(P) - P) - \psi^2(P)
+    // (See bls12_377.sage).
+    // Note that in this case we check that:
+    //   P + [t](\psi(P) - P) = \psi^2(P)
+    // since G2_variable cannot represent 0 (in G2).
+
+    // Check P is well-formed
+    libsnark::G2_checker_gadget<wppT> _P_checker;
+    // \psi(P) - P
+    G2_add_gadget<wppT> _psi_P_minus_P;
+    // [t](\psi(P) - P)
+    G2_mul_by_const_scalar_gadget<wppT, libff::bls12_377_r_limbs>
+        _t_times_psi_P_minus_P;
+    // P + [t](\psi(P) - P)
+    G2_add_gadget<wppT> _P_plus_t_times_psi_P_minus_P;
+    // P + [t](\psi(P) - P) = \psi^2(P)
+    G2_equality_gadget<wppT> _h1_r_P_equals_zero;
+
+    bls12_377_G2_membership_check_gadget(
+        libsnark::protoboard<libff::Fr<wppT>> &pb,
+        libsnark::G2_variable<wppT> &g2,
+        const std::string &annotation_prefix);
+    void generate_r1cs_constraints();
+    void generate_r1cs_witness();
+};
 
 } // namespace libzecale
 

--- a/libzecale/circuits/pairing/bls12_377_membership_check_gadgets.tcc
+++ b/libzecale/circuits/pairing/bls12_377_membership_check_gadgets.tcc
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2020 Clearmatics Technologies Ltd
+// Copyright (c) 2015-2021 Clearmatics Technologies Ltd
 //
 // SPDX-License-Identifier: LGPL-3.0+
 

--- a/libzecale/circuits/pairing/bls12_377_membership_check_gadgets.tcc
+++ b/libzecale/circuits/pairing/bls12_377_membership_check_gadgets.tcc
@@ -171,6 +171,7 @@ bls12_377_G2_membership_check_gadget<wppT>::
 template<typename wppT>
 void bls12_377_G2_membership_check_gadget<wppT>::generate_r1cs_constraints()
 {
+    _P_checker.generate_r1cs_constraints();
     _psi_P_minus_P.generate_r1cs_constraints();
     _t_times_psi_P_minus_P.generate_r1cs_constraints();
     _P_plus_t_times_psi_P_minus_P.generate_r1cs_constraints();
@@ -180,6 +181,8 @@ void bls12_377_G2_membership_check_gadget<wppT>::generate_r1cs_constraints()
 template<typename wppT>
 void bls12_377_G2_membership_check_gadget<wppT>::generate_r1cs_witness()
 {
+    _P_checker.generate_r1cs_witness();
+
     // Evaluate result of untwist_frobenius_twist and g2_variable_negate
     _psi_P_minus_P._A.X->evaluate();
     _psi_P_minus_P._A.Y->evaluate();

--- a/libzecale/circuits/pairing/bls12_377_membership_check_gadgets.tcc
+++ b/libzecale/circuits/pairing/bls12_377_membership_check_gadgets.tcc
@@ -146,7 +146,7 @@ bls12_377_G2_membership_check_gadget<wppT>::
     , _t_times_psi_P_minus_P(
           pb,
           libff::bls12_377_trace_of_frobenius,
-          _psi_P_minus_P._C,
+          _psi_P_minus_P._result,
           libsnark::G2_variable<wppT>(
               pb, FMT(annotation_prefix, " [t](psi(P)-P)")),
           FMT(annotation_prefix, " _t_times_psi_P_minus_P"))
@@ -161,7 +161,7 @@ bls12_377_G2_membership_check_gadget<wppT>::
     // P + [t](\psi(P) - P) = \psi^2(P)
     , _h1_r_P_equals_zero(
           pb,
-          _P_plus_t_times_psi_P_minus_P._C,
+          _P_plus_t_times_psi_P_minus_P._result,
           bls12_377_g2_untwist_frobenius_twist(
               pb, P, 2, FMT(annotation_prefix, " psi^2(P)")),
           FMT(annotation_prefix, " _h1_r_P_is_zero"))

--- a/libzecale/circuits/pairing/bls12_377_membership_check_gadgets.tcc
+++ b/libzecale/circuits/pairing/bls12_377_membership_check_gadgets.tcc
@@ -1,0 +1,60 @@
+// Copyright (c) 2015-2020 Clearmatics Technologies Ltd
+//
+// SPDX-License-Identifier: LGPL-3.0+
+
+#ifndef __ZECALE_CIRCUITS_PAIRING_BLS12_377_MEMBERSHIP_CHECK_GADGETS_TCC__
+#define __ZECALE_CIRCUITS_PAIRING_BLS12_377_MEMBERSHIP_CHECK_GADGETS_TCC__
+
+#include "libzecale/circuits/pairing/bls12_377_membership_check_gadgets.hpp"
+
+namespace libzecale
+{
+
+// bls12_377_G2_membership_check_gadget
+
+template<typename wppT>
+bls12_377_G1_membership_check_gadget<wppT>::
+    bls12_377_G1_membership_check_gadget(
+        libsnark::protoboard<libff::Fr<wppT>> &pb,
+        const libsnark::G1_variable<wppT> &P,
+        const std::string &annotation_prefix)
+    : libsnark::gadget<libff::Fr<wppT>>(pb, annotation_prefix)
+    , _P(P)
+    , _P_primed(pb, FMT(annotation_prefix, " P_primed"))
+    , _P_primed_checker(
+          pb, _P_primed, FMT(annotation_prefix, " P_primed_checker"))
+    , _P_primed_mul_cofactor(
+          pb,
+          libff::G1<nppT>::h,
+          _P_primed,
+          P,
+          FMT(annotation_prefix, " mul_by_cofactor"))
+{
+}
+
+template<typename wppT>
+void bls12_377_G1_membership_check_gadget<wppT>::generate_r1cs_constraints()
+{
+    _P_primed_checker.generate_r1cs_constraints();
+    _P_primed_mul_cofactor.generate_r1cs_constraints();
+}
+
+template<typename wppT>
+void bls12_377_G1_membership_check_gadget<wppT>::generate_r1cs_witness()
+{
+    // P has already been witnessed. Compute P'.
+    const libff::G1<nppT> P_val(
+        this->pb.lc_val(_P.X), this->pb.lc_val(_P.Y), libff::Fq<nppT>::one());
+    const libff::G1<nppT> P_primed_val = P_val.proof_of_safe_subgroup();
+
+    // Witness P_primed and the multiplication gadget. Re-witness the result P,
+    // ensuring that the result is as expected.
+    _P_primed.generate_r1cs_witness(P_primed_val);
+    _P_primed_checker.generate_r1cs_witness();
+    _P_primed_mul_cofactor.generate_r1cs_witness();
+    _P.generate_r1cs_witness(P_val);
+}
+
+} // namespace libzecale
+
+#endif // __ZECALE_CIRCUITS_PAIRING_BLS12_377_MEMBERSHIP_CHECK_GADGETS_TCC__

--- a/libzecale/circuits/pairing/group_variable_gadgets.hpp
+++ b/libzecale/circuits/pairing/group_variable_gadgets.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2020 Clearmatics Technologies Ltd
+// Copyright (c) 2015-2021 Clearmatics Technologies Ltd
 //
 // SPDX-License-Identifier: LGPL-3.0+
 

--- a/libzecale/circuits/pairing/group_variable_gadgets.hpp
+++ b/libzecale/circuits/pairing/group_variable_gadgets.hpp
@@ -139,6 +139,14 @@ public:
     void generate_r1cs_witness();
 };
 
+template<typename wppT, mp_size_t scalarLimbs>
+using G2_mul_by_const_scalar_gadget = point_mul_by_const_scalar_gadget<
+    libff::G2<other_curve<wppT>>,
+    libsnark::G2_variable<wppT>,
+    G2_add_gadget<wppT>,
+    G2_dbl_gadget<wppT>,
+    libff::bigint<scalarLimbs>>;
+
 } // namespace libzecale
 
 #include "libzecale/circuits/pairing/group_variable_gadgets.tcc"

--- a/libzecale/circuits/pairing/group_variable_gadgets.hpp
+++ b/libzecale/circuits/pairing/group_variable_gadgets.hpp
@@ -78,34 +78,34 @@ class G2_add_gadget : public libsnark::gadget<libff::Fr<wppT>>
 public:
     libsnark::G2_variable<wppT> _A;
     libsnark::G2_variable<wppT> _B;
-    libsnark::G2_variable<wppT> _C;
+    libsnark::G2_variable<wppT> _result;
 
     libsnark::Fqe_variable<wppT> _lambda;
 
     // For curve points A = (Ax, Ay), B = (Bx, By), we have that
-    // A + B = C = (Cx, Cy) is given by:
+    // A + B = R = (Rx, Ry) is given by:
     //
-    //   Cx = lambda^2 - Ax - Bx
-    //   Cy = lambda*(Ax - Cx) - Ay
+    //   Rx = lambda^2 - Ax - Bx
+    //   Ry = lambda*(Ax - Rx) - Ay
     //   where lambda = (By - Ay) / (Bx - Ax)
 
     // lambda = (By - Ay) / (Bx - Ax)
     // <=>  lambda * (Bx - Ax) = By - Ay
     libsnark::Fqe_mul_gadget<wppT> _lambda_constraint;
 
-    // Cx = lambda^2 - Ax - Bx
-    // <=> lambda^2 = Cx + Ax + Bx
-    libsnark::Fqe_mul_gadget<wppT> _Cx_constraint;
+    // Rx = lambda^2 - Ax - Bx
+    // <=> lambda^2 = Rx + Ax + Bx
+    libsnark::Fqe_mul_gadget<wppT> _Rx_constraint;
 
-    // Cy = lambda * (Ax - Cx) - Ay
-    // <=> lambda * (Ax - Cx) = Cy + Ay
-    libsnark::Fqe_mul_gadget<wppT> _Cy_constraint;
+    // Ry = lambda * (Ax - Rx) - Ay
+    // <=> lambda * (Ax - Rx) = Ry + Ay
+    libsnark::Fqe_mul_gadget<wppT> _Ry_constraint;
 
     G2_add_gadget(
         libsnark::protoboard<libff::Fr<wppT>> &pb,
         const libsnark::G2_variable<wppT> &A,
         const libsnark::G2_variable<wppT> &B,
-        const libsnark::G2_variable<wppT> &C,
+        const libsnark::G2_variable<wppT> &R,
         const std::string &annotation_prefix);
     void generate_r1cs_constraints();
     void generate_r1cs_witness();

--- a/libzecale/circuits/pairing/group_variable_gadgets.hpp
+++ b/libzecale/circuits/pairing/group_variable_gadgets.hpp
@@ -81,22 +81,24 @@ public:
     libsnark::G2_variable<wppT> _C;
 
     libsnark::Fqe_variable<wppT> _lambda;
-    libsnark::Fqe_variable<wppT> _nu;
+
+    // For curve points A = (Ax, Ay), B = (Bx, By), we have that
+    // A + B = C = (Cx, Cy) is given by:
+    //
+    //   Cx = lambda^2 - Ax - Bx
+    //   Cy = lambda*(Ax - Cx) - Ay
+    //   where lambda = (By - Ay) / (Bx - Ax)
 
     // lambda = (By - Ay) / (Bx - Ax)
     // <=>  lambda * (Bx - Ax) = By - Ay
     libsnark::Fqe_mul_gadget<wppT> _lambda_constraint;
 
-    // nu = Ay - lambda * Ax
-    // <=> lambda * Ax = Ay - nu
-    libsnark::Fqe_mul_gadget<wppT> _nu_constraint;
-
     // Cx = lambda^2 - Ax - Bx
     // <=> lambda^2 = Cx + Ax + Bx
     libsnark::Fqe_mul_gadget<wppT> _Cx_constraint;
 
-    // Cy = -(lambda * Cx + nu)
-    // <=> Cx * lambda = -Cy - nu
+    // Cy = lambda * (Ax - Cx) - Ay
+    // <=> lambda * (Ax - Cx) = Cy + Ay
     libsnark::Fqe_mul_gadget<wppT> _Cy_constraint;
 
     G2_add_gadget(
@@ -118,7 +120,13 @@ public:
     libsnark::G2_variable<wppT> _B;
 
     libsnark::Fqe_variable<wppT> _lambda;
-    libsnark::Fqe_variable<wppT> _nu;
+
+    // For a curve point A = (Ax, Ay), we have that A + A = B = (Bx, By) is
+    // given by:
+    //
+    //   Bx = lambda^2 - 2 * Ax
+    //   By = lambda*(Ax - Bx) - Ay
+    //   where lambda = (3 * Ax^2) / 2 * Ay
 
     // Ax_squared = Ax * Ax
     libsnark::Fqe_mul_gadget<wppT> _Ax_squared_constraint;
@@ -127,16 +135,12 @@ public:
     // <=> lambda * (Ay + Ay) = 3 * Ax_squared + a
     libsnark::Fqe_mul_gadget<wppT> _lambda_constraint;
 
-    // nu = Ay - lambda * Ax
-    // <=> lambda * Ax = Ay - nu
-    libsnark::Fqe_mul_gadget<wppT> _nu_constraint;
-
     // Bx = lambda^2 - 2 * Ax
     // <=> lambda * lambda = Bx + Ax + Ax
     libsnark::Fqe_mul_gadget<wppT> _Bx_constraint;
 
-    // By = - (lambda * Bx + nu)
-    // <=> lambda * Bx = - By - nu
+    // By = lambda * (Ax - Bx) - Ay
+    // <=> lambda * (Ax - Bx) = By + Ay
     libsnark::Fqe_mul_gadget<wppT> _By_constraint;
 
     G2_dbl_gadget(

--- a/libzecale/circuits/pairing/group_variable_gadgets.hpp
+++ b/libzecale/circuits/pairing/group_variable_gadgets.hpp
@@ -1,8 +1,9 @@
 // Copyright (c) 2015-2020 Clearmatics Technologies Ltd
 //
 // SPDX-License-Identifier: LGPL-3.0+
-#ifndef __ZECALE_CIRCUITS_PAIRING_POINT_MULTIPLICATION_GADGETS_HPP__
-#define __ZECALE_CIRCUITS_PAIRING_POINT_MULTIPLICATION_GADGETS_HPP__
+
+#ifndef __ZECALE_CIRCUITS_PAIRING_GROUP_VARIABLE_GADGETS_HPP__
+#define __ZECALE_CIRCUITS_PAIRING_GROUP_VARIABLE_GADGETS_HPP__
 
 #include "libzecale/circuits/pairing/pairing_params.hpp"
 
@@ -125,6 +126,6 @@ public:
 
 } // namespace libzecale
 
-#include "libzecale/circuits/pairing/point_multiplication_gadgets.tcc"
+#include "libzecale/circuits/pairing/group_variable_gadgets.tcc"
 
-#endif // __ZECALE_CIRCUITS_PAIRING_POINT_MULTIPLICATION_GADGETS_HPP__
+#endif // __ZECALE_CIRCUITS_PAIRING_GROUP_VARIABLE_GADGETS_HPP__

--- a/libzecale/circuits/pairing/group_variable_gadgets.hpp
+++ b/libzecale/circuits/pairing/group_variable_gadgets.hpp
@@ -23,6 +23,15 @@ template<typename wppT>
 libff::G2<other_curve<wppT>> g2_variable_get_element(
     const libsnark::G2_variable<wppT> &var);
 
+/// Negate a G2 variable and return the result. (Note that evaluate should be
+/// called on the result, or its components, before using it in witness
+/// generation).
+template<typename wppT>
+libsnark::G2_variable<wppT> g2_variable_negate(
+    libsnark::protoboard<libff::Fr<wppT>> &pb,
+    const libsnark::G2_variable<wppT> &g2,
+    const std::string &annotation_prefix);
+
 /// Generic gadget to perform scalar multiplication of group variables.
 template<
     typename groupT,

--- a/libzecale/circuits/pairing/group_variable_gadgets.hpp
+++ b/libzecale/circuits/pairing/group_variable_gadgets.hpp
@@ -23,29 +23,44 @@ template<typename wppT>
 libff::G2<other_curve<wppT>> g2_variable_get_element(
     const libsnark::G2_variable<wppT> &var);
 
-template<typename wppT, mp_size_t scalarLimbs>
-class G1_mul_by_const_scalar_gadget : libsnark::gadget<libff::Fr<wppT>>
+/// Generic gadget to perform scalar multiplication of group variables.
+template<
+    typename groupT,
+    typename groupVariableT,
+    typename add_gadget,
+    typename dbl_gadget,
+    typename scalarT>
+class point_mul_by_const_scalar_gadget
+    : libsnark::gadget<typename groupT::base_field>
 {
 public:
-    using Field = libff::Fr<wppT>;
-    using add_gadget = libsnark::G1_add_gadget<wppT>;
-    using dbl_gadget = libsnark::G1_dbl_gadget<wppT>;
+    using FieldT = typename groupT::base_field;
 
-    const libff::bigint<scalarLimbs> _scalar;
+    const scalarT _scalar;
+    const groupVariableT _result;
     std::vector<std::shared_ptr<add_gadget>> _add_gadgets;
     std::vector<std::shared_ptr<dbl_gadget>> _dbl_gadgets;
-    const libsnark::G1_variable<wppT> &_result;
 
-    G1_mul_by_const_scalar_gadget(
-        libsnark::protoboard<libff::Fr<wppT>> &pb,
-        const libff::bigint<scalarLimbs> &scalar,
-        const libsnark::G1_variable<wppT> &P,
-        const libsnark::G1_variable<wppT> &result,
+    point_mul_by_const_scalar_gadget(
+        libsnark::protoboard<FieldT> &pb,
+        const scalarT &scalar,
+        const groupVariableT &P,
+        const groupVariableT &result,
         const std::string &annotation_prefix);
 
     void generate_r1cs_constraints();
     void generate_r1cs_witness();
+    const groupVariableT &result() const;
 };
+
+/// Gadget for scalar multiplication of G1 elements
+template<typename wppT, mp_size_t scalarLimbs>
+using G1_mul_by_const_scalar_gadget = point_mul_by_const_scalar_gadget<
+    libff::G1<other_curve<wppT>>,
+    libsnark::G1_variable<wppT>,
+    libsnark::G1_add_gadget<wppT>,
+    libsnark::G1_dbl_gadget<wppT>,
+    libff::bigint<scalarLimbs>>;
 
 /// Gadget to add 2 G2 points
 template<typename wppT>

--- a/libzecale/circuits/pairing/group_variable_gadgets.hpp
+++ b/libzecale/circuits/pairing/group_variable_gadgets.hpp
@@ -156,6 +156,35 @@ using G2_mul_by_const_scalar_gadget = point_mul_by_const_scalar_gadget<
     G2_dbl_gadget<wppT>,
     libff::bigint<scalarLimbs>>;
 
+template<typename wppT>
+class G2_equality_gadget : libsnark::gadget<libff::Fr<wppT>>
+{
+public:
+    using nppT = other_curve<wppT>;
+
+    libsnark::G2_variable<wppT> _A;
+    libsnark::G2_variable<wppT> _B;
+
+    G2_equality_gadget(
+        libsnark::protoboard<libff::Fr<wppT>> &pb,
+        const libsnark::G2_variable<wppT> &A,
+        const libsnark::G2_variable<wppT> &B,
+        const std::string &annotation_prefix);
+    void generate_r1cs_constraints();
+    void generate_r1cs_witness();
+
+private:
+    // There is no generic way to iterate over the components of Fp?_variable,
+    // so this method must be specialized per field extension. However, the
+    // version that expects 2 components may still compile on Fp3_variable,
+    // say. Hence we specify Fp2_variable explicitly in the parameters to avoid
+    // callers accidentally using this for other pairings and passing in
+    // Fp?_variable.
+    void generate_fpe_equality_constraints(
+        const libsnark::Fp2_variable<libff::Fqe<nppT>> &a,
+        const libsnark::Fp2_variable<libff::Fqe<nppT>> &b);
+};
+
 } // namespace libzecale
 
 #include "libzecale/circuits/pairing/group_variable_gadgets.tcc"

--- a/libzecale/circuits/pairing/group_variable_gadgets.tcc
+++ b/libzecale/circuits/pairing/group_variable_gadgets.tcc
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2020 Clearmatics Technologies Ltd
+// Copyright (c) 2015-2021 Clearmatics Technologies Ltd
 //
 // SPDX-License-Identifier: LGPL-3.0+
 

--- a/libzecale/circuits/pairing/group_variable_gadgets.tcc
+++ b/libzecale/circuits/pairing/group_variable_gadgets.tcc
@@ -395,6 +395,45 @@ template<typename wppT> void G2_dbl_gadget<wppT>::generate_r1cs_witness()
     _By_constraint.generate_r1cs_witness();
 }
 
+// G2_is_zero_gadget
+
+template<typename wppT>
+G2_equality_gadget<wppT>::G2_equality_gadget(
+    libsnark::protoboard<libff::Fr<wppT>> &pb,
+    const libsnark::G2_variable<wppT> &A,
+    const libsnark::G2_variable<wppT> &B,
+    const std::string &annotation_prefix)
+    : libsnark::gadget<libff::Fr<wppT>>(pb, annotation_prefix), _A(A), _B(B)
+{
+}
+
+template<typename wppT>
+void G2_equality_gadget<wppT>::generate_r1cs_constraints()
+{
+    // A.X == B.X
+    generate_fpe_equality_constraints(*_A.X, *_B.X);
+    // A.Y == B.Y
+    generate_fpe_equality_constraints(*_A.X, *_B.X);
+}
+
+template<typename wppT> void G2_equality_gadget<wppT>::generate_r1cs_witness()
+{
+    // Nothing to do
+}
+
+template<typename wppT>
+void G2_equality_gadget<wppT>::generate_fpe_equality_constraints(
+    const libsnark::Fp2_variable<libff::Fqe<nppT>> &a,
+    const libsnark::Fp2_variable<libff::Fqe<nppT>> &b)
+{
+    this->pb.add_r1cs_constraint(
+        libsnark::r1cs_constraint<libff::Fr<wppT>>(a.c0, 1, b.c0),
+        FMT(this->annotation_prefix, " c0"));
+    this->pb.add_r1cs_constraint(
+        libsnark::r1cs_constraint<libff::Fr<wppT>>(a.c1, 1, b.c1),
+        FMT(this->annotation_prefix, " c1"));
+}
+
 } // namespace libzecale
 
 #endif // __ZECALE_CIRCUITS_PAIRING_GROUP_VARIABLE_GADGETS_TCC__

--- a/libzecale/circuits/pairing/group_variable_gadgets.tcc
+++ b/libzecale/circuits/pairing/group_variable_gadgets.tcc
@@ -2,15 +2,15 @@
 //
 // SPDX-License-Identifier: LGPL-3.0+
 
-#ifndef __ZECALE_CIRCUITS_PAIRING_POINT_MULTIPLICATION_GADGETS_TCC__
-#define __ZECALE_CIRCUITS_PAIRING_POINT_MULTIPLICATION_GADGETS_TCC__
+#ifndef __ZECALE_CIRCUITS_PAIRING_GROUP_VARIABLE_GADGETS_TCC__
+#define __ZECALE_CIRCUITS_PAIRING_GROUP_VARIABLE_GADGETS_TCC__
 
-#include "libzecale/circuits/pairing/point_multiplication_gadgets.hpp"
+#include "libzecale/circuits/pairing/group_variable_gadgets.hpp"
 
 namespace libzecale
 {
 
-namespace implementation
+namespace internal
 {
 
 // Internal class used to extract the value of a G1_variable.
@@ -28,13 +28,13 @@ public:
     }
 };
 
-} // namespace implementation
+} // namespace internal
 
 template<typename wppT>
 libff::G1<other_curve<wppT>> g1_variable_get_element(
     const libsnark::G1_variable<wppT> &var)
 {
-    return ((implementation::G1_variable_with_get_element<wppT> *)(&var))
+    return ((internal::G1_variable_with_get_element<wppT> *)(&var))
         ->get_element();
 }
 
@@ -342,4 +342,4 @@ template<typename wppT> void G2_dbl_gadget<wppT>::generate_r1cs_witness()
 
 } // namespace libzecale
 
-#endif // __ZECALE_CIRCUITS_PAIRING_POINT_MULTIPLICATION_GADGETS_TCC__
+#endif // __ZECALE_CIRCUITS_PAIRING_GROUP_VARIABLE_GADGETS_TCC__

--- a/libzecale/circuits/pairing/group_variable_gadgets.tcc
+++ b/libzecale/circuits/pairing/group_variable_gadgets.tcc
@@ -49,6 +49,15 @@ libff::G2<other_curve<wppT>> g2_variable_get_element(
         libff::G2<nppT>::twist_field::one());
 }
 
+template<typename wppT>
+libsnark::G2_variable<wppT> g2_variable_negate(
+    libsnark::protoboard<libff::Fr<wppT>> &pb,
+    const libsnark::G2_variable<wppT> &g2,
+    const std::string &annotation_prefix)
+{
+    return libsnark::G2_variable<wppT>(pb, *g2.X, -*g2.Y, annotation_prefix);
+}
+
 // point_mul_by_const_scalar_gadget
 
 template<

--- a/libzecale/circuits/pairing/point_multiplication_gadgets.hpp
+++ b/libzecale/circuits/pairing/point_multiplication_gadgets.hpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2015-2020 Clearmatics Technologies Ltd
+//
+// SPDX-License-Identifier: LGPL-3.0+
+#ifndef __ZECALE_CIRCUITS_PAIRING_POINT_MULTIPLICATION_GADGETS_HPP__
+#define __ZECALE_CIRCUITS_PAIRING_POINT_MULTIPLICATION_GADGETS_HPP__
+
+#include "libzecale/circuits/pairing/pairing_params.hpp"
+
+#include <libsnark/gadgetlib1/gadgets/curves/weierstrass_g1_gadget.hpp>
+#include <libsnark/gadgetlib1/gadgets/curves/weierstrass_g2_gadget.hpp>
+
+namespace libzecale
+{
+
+/// Utility function to get the value from a (witnessed) G1_variable.
+template<typename wppT>
+libff::G1<other_curve<wppT>> g1_variable_get_element(
+    const libsnark::G1_variable<wppT> &g1_variable);
+
+/// Utility function to get the value from a (witnessed) G2_variable.
+template<typename wppT>
+libff::G2<other_curve<wppT>> g2_variable_get_element(
+    const libsnark::G2_variable<wppT> &var);
+
+} // namespace libzecale
+
+#include "libzecale/circuits/pairing/point_multiplication_gadgets.tcc"
+
+#endif // __ZECALE_CIRCUITS_PAIRING_POINT_MULTIPLICATION_GADGETS_HPP__

--- a/libzecale/circuits/pairing/point_multiplication_gadgets.hpp
+++ b/libzecale/circuits/pairing/point_multiplication_gadgets.hpp
@@ -84,6 +84,45 @@ public:
     void generate_r1cs_witness();
 };
 
+template<typename wppT> class G2_dbl_gadget : libsnark::gadget<libff::Fr<wppT>>
+{
+public:
+    using nppT = other_curve<wppT>;
+
+    libsnark::G2_variable<wppT> _A;
+    libsnark::G2_variable<wppT> _B;
+
+    libsnark::Fqe_variable<wppT> _lambda;
+    libsnark::Fqe_variable<wppT> _nu;
+
+    // Ax_squared = Ax * Ax
+    libsnark::Fqe_mul_gadget<wppT> _Ax_squared_constraint;
+
+    // lambda = (3 * Ax^2 + a) / 2 * Ay
+    // <=> lambda * (Ay + Ay) = 3 * Ax_squared + a
+    libsnark::Fqe_mul_gadget<wppT> _lambda_constraint;
+
+    // nu = Ay - lambda * Ax
+    // <=> lambda * Ax = Ay - nu
+    libsnark::Fqe_mul_gadget<wppT> _nu_constraint;
+
+    // Bx = lambda^2 - 2 * Ax
+    // <=> lambda * lambda = Bx + Ax + Ax
+    libsnark::Fqe_mul_gadget<wppT> _Bx_constraint;
+
+    // By = - (lambda * Bx + nu)
+    // <=> lambda * Bx = - By - nu
+    libsnark::Fqe_mul_gadget<wppT> _By_constraint;
+
+    G2_dbl_gadget(
+        libsnark::protoboard<libff::Fr<wppT>> &pb,
+        const libsnark::G2_variable<wppT> &A,
+        const libsnark::G2_variable<wppT> &B,
+        const std::string &annotation_prefix);
+    void generate_r1cs_constraints();
+    void generate_r1cs_witness();
+};
+
 } // namespace libzecale
 
 #include "libzecale/circuits/pairing/point_multiplication_gadgets.tcc"

--- a/libzecale/circuits/pairing/point_multiplication_gadgets.hpp
+++ b/libzecale/circuits/pairing/point_multiplication_gadgets.hpp
@@ -46,6 +46,44 @@ public:
     void generate_r1cs_witness();
 };
 
+/// Gadget to add 2 G2 points
+template<typename wppT>
+class G2_add_gadget : public libsnark::gadget<libff::Fr<wppT>>
+{
+public:
+    libsnark::G2_variable<wppT> _A;
+    libsnark::G2_variable<wppT> _B;
+    libsnark::G2_variable<wppT> _C;
+
+    libsnark::Fqe_variable<wppT> _lambda;
+    libsnark::Fqe_variable<wppT> _nu;
+
+    // lambda = (By - Ay) / (Bx - Ax)
+    // <=>  lambda * (Bx - Ax) = By - Ay
+    libsnark::Fqe_mul_gadget<wppT> _lambda_constraint;
+
+    // nu = Ay - lambda * Ax
+    // <=> lambda * Ax = Ay - nu
+    libsnark::Fqe_mul_gadget<wppT> _nu_constraint;
+
+    // Cx = lambda^2 - Ax - Bx
+    // <=> lambda^2 = Cx + Ax + Bx
+    libsnark::Fqe_mul_gadget<wppT> _Cx_constraint;
+
+    // Cy = -(lambda * Cx + nu)
+    // <=> Cx * lambda = -Cy - nu
+    libsnark::Fqe_mul_gadget<wppT> _Cy_constraint;
+
+    G2_add_gadget(
+        libsnark::protoboard<libff::Fr<wppT>> &pb,
+        const libsnark::G2_variable<wppT> &A,
+        const libsnark::G2_variable<wppT> &B,
+        const libsnark::G2_variable<wppT> &C,
+        const std::string &annotation_prefix);
+    void generate_r1cs_constraints();
+    void generate_r1cs_witness();
+};
+
 } // namespace libzecale
 
 #include "libzecale/circuits/pairing/point_multiplication_gadgets.tcc"

--- a/libzecale/circuits/pairing/point_multiplication_gadgets.hpp
+++ b/libzecale/circuits/pairing/point_multiplication_gadgets.hpp
@@ -22,6 +22,30 @@ template<typename wppT>
 libff::G2<other_curve<wppT>> g2_variable_get_element(
     const libsnark::G2_variable<wppT> &var);
 
+template<typename wppT, mp_size_t scalarLimbs>
+class G1_mul_by_const_scalar_gadget : libsnark::gadget<libff::Fr<wppT>>
+{
+public:
+    using Field = libff::Fr<wppT>;
+    using add_gadget = libsnark::G1_add_gadget<wppT>;
+    using dbl_gadget = libsnark::G1_dbl_gadget<wppT>;
+
+    const libff::bigint<scalarLimbs> _scalar;
+    std::vector<std::shared_ptr<add_gadget>> _add_gadgets;
+    std::vector<std::shared_ptr<dbl_gadget>> _dbl_gadgets;
+    const libsnark::G1_variable<wppT> &_result;
+
+    G1_mul_by_const_scalar_gadget(
+        libsnark::protoboard<libff::Fr<wppT>> &pb,
+        const libff::bigint<scalarLimbs> &scalar,
+        const libsnark::G1_variable<wppT> &P,
+        const libsnark::G1_variable<wppT> &result,
+        const std::string &annotation_prefix);
+
+    void generate_r1cs_constraints();
+    void generate_r1cs_witness();
+};
+
 } // namespace libzecale
 
 #include "libzecale/circuits/pairing/point_multiplication_gadgets.tcc"

--- a/libzecale/circuits/pairing/point_multiplication_gadgets.tcc
+++ b/libzecale/circuits/pairing/point_multiplication_gadgets.tcc
@@ -1,0 +1,54 @@
+// Copyright (c) 2015-2020 Clearmatics Technologies Ltd
+//
+// SPDX-License-Identifier: LGPL-3.0+
+
+#ifndef __ZECALE_CIRCUITS_PAIRING_POINT_MULTIPLICATION_GADGETS_TCC__
+#define __ZECALE_CIRCUITS_PAIRING_POINT_MULTIPLICATION_GADGETS_TCC__
+
+#include "libzecale/circuits/pairing/point_multiplication_gadgets.hpp"
+
+namespace libzecale
+{
+
+namespace implementation
+{
+
+// Internal class used to extract the value of a G1_variable.
+template<typename wppT>
+class G1_variable_with_get_element : public libsnark::G1_variable<wppT>
+{
+public:
+    using nppT = other_curve<wppT>;
+    inline libff::G1<nppT> get_element() const
+    {
+        return libff::G1<nppT>(
+            this->pb.lc_val(this->X),
+            this->pb.lc_val(this->Y),
+            libff::Fq<nppT>::one());
+    }
+};
+
+} // namespace implementation
+
+template<typename wppT>
+libff::G1<other_curve<wppT>> g1_variable_get_element(
+    const libsnark::G1_variable<wppT> &var)
+{
+    return ((implementation::G1_variable_with_get_element<wppT> *)(&var))
+        ->get_element();
+}
+
+template<typename wppT>
+libff::G2<other_curve<wppT>> g2_variable_get_element(
+    const libsnark::G2_variable<wppT> &var)
+{
+    using nppT = other_curve<wppT>;
+    return libff::G2<nppT>(
+        var.X->get_element(),
+        var.Y->get_element(),
+        libff::G2<nppT>::twist_field::one());
+}
+
+} // namespace libzecale
+
+#endif // __ZECALE_CIRCUITS_PAIRING_POINT_MULTIPLICATION_GADGETS_TCC__

--- a/libzecale/circuits/pairing/point_multiplication_gadgets.tcc
+++ b/libzecale/circuits/pairing/point_multiplication_gadgets.tcc
@@ -49,6 +49,109 @@ libff::G2<other_curve<wppT>> g2_variable_get_element(
         libff::G2<nppT>::twist_field::one());
 }
 
+// G1_mul_by_const_scalar_gadget
+
+template<typename wppT, mp_size_t scalarLimbs>
+G1_mul_by_const_scalar_gadget<wppT, scalarLimbs>::G1_mul_by_const_scalar_gadget(
+    libsnark::protoboard<libff::Fr<wppT>> &pb,
+    const libff::bigint<scalarLimbs> &scalar,
+    const libsnark::G1_variable<wppT> &P,
+    const libsnark::G1_variable<wppT> &result,
+    const std::string &annotation_prefix)
+    : libsnark::gadget<libff::Fr<wppT>>(pb, annotation_prefix)
+    , _scalar(scalar)
+    , _result(result)
+{
+    const size_t last_bit = _scalar.num_bits() - 1;
+    const libsnark::G1_variable<wppT> *last_value = &P;
+
+    // Temporary vector of intermediate variables. Reserve the maximum number
+    // of possible entries to ensure no reallocation (i.e. last_value is always
+    // valid).
+    std::vector<libsnark::G1_variable<wppT>> values;
+    values.reserve(2 * last_bit);
+
+    for (size_t i = last_bit - 1; i > 0; --i) {
+        // Double
+        values.emplace_back(pb, FMT(annotation_prefix, " value[%zu]", i));
+        _dbl_gadgets.emplace_back(new dbl_gadget(
+            pb,
+            *last_value,
+            values.back(),
+            FMT(annotation_prefix, " double[%zu]", i)));
+        last_value = &values.back();
+
+        // Add
+        if (_scalar.test_bit(i)) {
+            values.emplace_back(pb, FMT(annotation_prefix, " value[%zu]", i));
+            _add_gadgets.emplace_back(new add_gadget(
+                pb,
+                *last_value,
+                P,
+                values.back(),
+                FMT(annotation_prefix, " add[%zu]", i)));
+            last_value = &values.back();
+        }
+    }
+
+    // Depending on the value of the final (lowest-order) bit, perform final
+    // double or double-and-add into _result.
+
+    if (_scalar.test_bit(0)) {
+        // Double
+        values.emplace_back(pb, FMT(annotation_prefix, " value[0]"));
+        _dbl_gadgets.emplace_back(new dbl_gadget(
+            pb,
+            *last_value,
+            values.back(),
+            FMT(annotation_prefix, " double[0]")));
+        last_value = &values.back();
+
+        // Add into _result
+        _add_gadgets.emplace_back(new add_gadget(
+            pb, *last_value, P, _result, FMT(annotation_prefix, " add[0]")));
+    } else {
+        // Double
+        _dbl_gadgets.emplace_back(new dbl_gadget(
+            pb, *last_value, _result, FMT(annotation_prefix, " double[0]")));
+    }
+}
+
+template<typename wppT, mp_size_t scalarLimbs>
+void G1_mul_by_const_scalar_gadget<wppT, scalarLimbs>::
+    generate_r1cs_constraints()
+{
+    const size_t last_bit = _scalar.num_bits() - 1;
+    size_t dbl_idx = 0;
+    size_t add_idx = 0;
+    for (ssize_t i = last_bit - 1; i >= 0; --i) {
+        // Double gadget constraints
+        _dbl_gadgets[dbl_idx++]->generate_r1cs_constraints();
+
+        // Add gadget constraints
+        if (_scalar.test_bit(i)) {
+            _add_gadgets[add_idx++]->generate_r1cs_constraints();
+        }
+    }
+}
+
+template<typename wppT, mp_size_t scalarLimbs>
+void G1_mul_by_const_scalar_gadget<wppT, scalarLimbs>::generate_r1cs_witness()
+{
+    const size_t last_bit = _scalar.num_bits() - 1;
+    size_t dbl_idx = 0;
+    size_t add_idx = 0;
+    for (ssize_t i = last_bit - 1; i >= 0; --i) {
+        // Double gadget constraints
+        _dbl_gadgets[dbl_idx++]->generate_r1cs_witness();
+
+        // Add gadget constraints
+        if (_scalar.test_bit(i)) {
+            _add_gadgets[add_idx++]->generate_r1cs_witness();
+        }
+    }
+}
+
 } // namespace libzecale
 
 #endif // __ZECALE_CIRCUITS_PAIRING_POINT_MULTIPLICATION_GADGETS_TCC__

--- a/libzecale/tests/aggregator/aggregator_test.cpp
+++ b/libzecale/tests/aggregator/aggregator_test.cpp
@@ -27,10 +27,32 @@ using namespace libzeth;
 // because now, a digest can be fully packed into a field element without
 // residual bits
 
+namespace libzeth
+{
+
+// Use mimc7 by default
+template<> class tree_hash_selector<libff::mnt4_Fr>
+{
+public:
+    using tree_hash = MiMC_mp_gadget<
+        libff::mnt4_Fr,
+        MiMC_permutation_gadget<libff::mnt4_Fr, 7, 91>>;
+};
+template<> class tree_hash_selector<libff::mnt6_Fr>
+{
+public:
+    using tree_hash = MiMC_mp_gadget<
+        libff::mnt6_Fr,
+        MiMC_permutation_gadget<libff::mnt6_Fr, 7, 91>>;
+};
+
+} // namespace libzeth
+
 // The templates and constants used in the Zeth circuit.
 template<typename nppT> using hash = libzeth::BLAKE2s_256<libff::Fr<nppT>>;
 template<typename nppT>
-using hashTree = libzeth::MiMC_mp_gadget<libff::Fr<nppT>>;
+using hashTree =
+    typename libzeth::tree_hash_selector<libff::Fr<nppT>>::tree_hash;
 
 static const size_t tree_depth = 4;
 static const size_t inputs_number = 2;
@@ -313,11 +335,6 @@ template<typename nppT, typename wppT> void aggregator_test_pghr13()
         wppT,
         libzeth::pghr13_snark<wppT>,
         libzecale::pghr13_verifier_parameters<wppT>>();
-}
-
-TEST(AggregatorTests, AggregatorMnt4Mnt6Groth16)
-{
-    aggregator_test_groth16<libff::mnt4_pp, libff::mnt6_pp>();
 }
 
 TEST(AggregatorTests, AggregatorBls12Bw6Groth16)

--- a/libzecale/tests/circuits/bls12_377_membership_check_test.cpp
+++ b/libzecale/tests/circuits/bls12_377_membership_check_test.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2020 Clearmatics Technologies Ltd
+// Copyright (c) 2015-2021 Clearmatics Technologies Ltd
 //
 // SPDX-License-Identifier: LGPL-3.0+
 

--- a/libzecale/tests/circuits/bls12_377_membership_check_test.cpp
+++ b/libzecale/tests/circuits/bls12_377_membership_check_test.cpp
@@ -1,0 +1,60 @@
+// Copyright (c) 2015-2020 Clearmatics Technologies Ltd
+//
+// SPDX-License-Identifier: LGPL-3.0+
+
+#include "libzecale/circuits/pairing/bls12_377_membership_check_gadgets.hpp"
+#include "libzecale/circuits/pairing/bw6_761_pairing_params.hpp"
+
+#include <gtest/gtest.h>
+#include <libff/algebra/curves/bls12_377/bls12_377_pp.hpp>
+#include <libff/algebra/curves/bw6_761/bw6_761_pp.hpp>
+#include <libff/algebra/curves/curve_utils.hpp>
+#include <libzeth/snarks/groth16/groth16_snark.hpp>
+
+using wpp = libff::bw6_761_pp;
+using npp = libzecale::other_curve<wpp>;
+using snark = libzeth::groth16_snark<wpp>;
+using Field = libff::Fr<wpp>;
+
+namespace
+{
+
+void populate_g1_membership_check_circuit(
+    libsnark::protoboard<Field> &pb, const libff::G1<npp> &g1_value)
+{
+    libsnark::G1_variable<wpp> g1(pb, " g1");
+    libzecale::bls12_377_G1_membership_check_gadget<wpp> check_g1(
+        pb, g1, "check_g1");
+
+    check_g1.generate_r1cs_constraints();
+
+    g1.generate_r1cs_witness(g1_value);
+    check_g1.generate_r1cs_witness();
+}
+
+TEST(BLS12_377_Membership_Check, G1ValidMember)
+{
+    const libff::G1<npp> g1_valid = libff::Fr<npp>(3) * libff::G1<npp>::one();
+    libsnark::protoboard<Field> pb;
+    populate_g1_membership_check_circuit(pb, g1_valid);
+    ASSERT_TRUE(pb.is_satisfied());
+}
+
+TEST(BLS12_377_Membership_Check, G1InvalidMember)
+{
+    const libff::G1<npp> invalid_element =
+        libff::g1_curve_point_at_x<libff::G1<npp>>(libff::Fq<npp>(3));
+    libsnark::protoboard<Field> pb;
+    populate_g1_membership_check_circuit(pb, invalid_element);
+    ASSERT_FALSE(pb.is_satisfied());
+}
+
+} // namespace
+
+int main(int argc, char **argv)
+{
+    libff::bls12_377_pp::init_public_params();
+    libff::bw6_761_pp::init_public_params();
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/libzecale/tests/circuits/bls12_377_membership_check_test.cpp
+++ b/libzecale/tests/circuits/bls12_377_membership_check_test.cpp
@@ -49,6 +49,24 @@ TEST(BLS12_377_Membership_Check, G1InvalidMember)
     ASSERT_FALSE(pb.is_satisfied());
 }
 
+TEST(BLS12_377_Membership_Check, G2UntwistFrobeniusTwist)
+{
+    const libff::G2<npp> g2_val = libff::Fr<npp>(3) * libff::G2<npp>::one();
+    const libff::G2<npp> g2_uft_val_expect = g2_val.untwist_frobenius_twist();
+
+    libsnark::protoboard<Field> pb;
+    libsnark::G2_variable<wpp> g2(pb, "g2");
+    libsnark::G2_variable<wpp> g2_uft =
+        libzecale::bls12_377_g2_untwist_frobenius_twist(pb, g2, 1, "g2_uft");
+    g2.generate_r1cs_witness(g2_val);
+
+    g2_uft.X->evaluate();
+    g2_uft.Y->evaluate();
+    const libff::G2<npp> g2_uft_val =
+        libzecale::g2_variable_get_element<wpp>(g2_uft);
+    ASSERT_EQ(g2_uft_val_expect, g2_uft_val);
+}
+
 } // namespace
 
 int main(int argc, char **argv)

--- a/libzecale/tests/circuits/bls12_377_membership_check_test.cpp
+++ b/libzecale/tests/circuits/bls12_377_membership_check_test.cpp
@@ -21,8 +21,6 @@ namespace
 
 void g1_membership_check_circuit(const libff::G1<npp> &g1_value)
 {
-    ASSERT_TRUE(g1_value.is_well_formed());
-
     libsnark::protoboard<Field> pb;
     libsnark::G1_variable<wpp> g1(pb, " g1");
     libzecale::bls12_377_G1_membership_check_gadget<wpp> check_g1(
@@ -33,13 +31,13 @@ void g1_membership_check_circuit(const libff::G1<npp> &g1_value)
     g1.generate_r1cs_witness(g1_value);
     check_g1.generate_r1cs_witness();
 
-    ASSERT_EQ(g1_value.is_in_safe_subgroup(), pb.is_satisfied());
+    ASSERT_EQ(
+        g1_value.is_well_formed() && g1_value.is_in_safe_subgroup(),
+        pb.is_satisfied());
 }
 
 void g2_membership_check_circuit(const libff::G2<npp> &g2_value)
 {
-    ASSERT_TRUE(g2_value.is_well_formed());
-
     libsnark::protoboard<Field> pb;
     libsnark::G2_variable<wpp> g2(pb, " g2");
     libzecale::bls12_377_G2_membership_check_gadget<wpp> check_g2(
@@ -50,7 +48,9 @@ void g2_membership_check_circuit(const libff::G2<npp> &g2_value)
     g2.generate_r1cs_witness(g2_value);
     check_g2.generate_r1cs_witness();
 
-    ASSERT_EQ(g2_value.is_in_safe_subgroup(), pb.is_satisfied());
+    ASSERT_EQ(
+        g2_value.is_well_formed() && g2_value.is_in_safe_subgroup(),
+        pb.is_satisfied());
 }
 
 TEST(BLS12_377_Membership_Check, G1ValidMember)
@@ -63,6 +63,14 @@ TEST(BLS12_377_Membership_Check, G1InvalidMember)
 {
     const libff::G1<npp> g1_invalid =
         libff::g1_curve_point_at_x<libff::G1<npp>>(libff::Fq<npp>(3));
+    g1_membership_check_circuit(g1_invalid);
+}
+
+TEST(BLS12_377_Membership_Check, G1NotWellFormed)
+{
+    const libff::G1<npp> g1_invalid(
+        libff::Fq<npp>::one(), libff::Fq<npp>::one(), libff::Fq<npp>::one());
+    ASSERT_FALSE(g1_invalid.is_well_formed());
     g1_membership_check_circuit(g1_invalid);
 }
 
@@ -95,6 +103,14 @@ TEST(BLS12_377_Membership_Check, G2InvalidMember)
     const libff::G2<npp> g2_invalid =
         libff::g2_curve_point_at_x<libff::G2<npp>>(
             libff::Fq<npp>(3) * libff::Fqe<npp>::one());
+    g2_membership_check_circuit(g2_invalid);
+}
+
+TEST(BLS12_377_Membership_Check, G2NotWellFormed)
+{
+    const libff::G2<npp> g2_invalid(
+        libff::Fqe<npp>::one(), libff::Fqe<npp>::one(), libff::Fqe<npp>::one());
+    ASSERT_FALSE(g2_invalid.is_well_formed());
     g2_membership_check_circuit(g2_invalid);
 }
 

--- a/libzecale/tests/circuits/fp12_2over3over2_gadgets_test.cpp
+++ b/libzecale/tests/circuits/fp12_2over3over2_gadgets_test.cpp
@@ -36,6 +36,16 @@ TEST(Fp12_2over3over2_Test, ConstantOperations)
             Fp2T(FieldT("23"), FieldT("24")),
             Fp2T(FieldT("25"), FieldT("26"))));
     const Fp2T fp2(FieldT("7"), FieldT("8"));
+    const Fp12T fp12(
+        Fp6T(
+            Fp2T(FieldT("25"), FieldT("26")),
+            Fp2T(FieldT("23"), FieldT("24")),
+            Fp2T(FieldT("21"), FieldT("22"))),
+        Fp6T(
+            Fp2T(FieldT("3"), FieldT("4")),
+            Fp2T(FieldT("5"), FieldT("6")),
+            Fp2T(FieldT("1"), FieldT("2"))));
+
     const Fp12T unitary = libff::bls12_377_final_exponentiation_first_chunk(a);
 
     const Fp12T a_frob_1 = a.Frobenius_map(1);
@@ -44,6 +54,7 @@ TEST(Fp12_2over3over2_Test, ConstantOperations)
     const Fp12T a_frob_6 = a.Frobenius_map(6);
     const Fp12T a_frob_12 = a.Frobenius_map(12);
     const Fp12T a_times_fp2 = fp2 * a;
+    const Fp12T a_times_fp12 = fp12 * a;
     const Fp12T unitary_inv = unitary.unitary_inverse();
 
     // Operations in a circuit
@@ -56,6 +67,7 @@ TEST(Fp12_2over3over2_Test, ConstantOperations)
     Fp12_variable a_frob_6_var = a_var.frobenius_map(6);
     Fp12_variable a_frob_12_var = a_var.frobenius_map(12);
     Fp12_variable a_times_fp2_var = a_var * fp2;
+    Fp12_variable a_times_fp12_var = a_var * fp12;
     Fp12_variable unitary_inv_var = unitary_var.unitary_inverse();
 
     const size_t num_primary_inputs = pb.num_inputs();
@@ -70,6 +82,7 @@ TEST(Fp12_2over3over2_Test, ConstantOperations)
     a_frob_6_var.evaluate();
     a_frob_12_var.evaluate();
     a_times_fp2_var.evaluate();
+    a_times_fp12_var.evaluate();
     unitary_inv_var.evaluate();
 
     ASSERT_EQ(a_frob_1, a_frob_1_var.get_element());
@@ -79,6 +92,7 @@ TEST(Fp12_2over3over2_Test, ConstantOperations)
     ASSERT_EQ(a_frob_12, a_frob_12_var.get_element());
     ASSERT_EQ(a, a_frob_12);
     ASSERT_EQ(a_times_fp2, a_times_fp2_var.get_element());
+    ASSERT_EQ(a_times_fp12, a_times_fp12_var.get_element());
     ASSERT_EQ(unitary_inv, unitary_inv_var.get_element());
 }
 

--- a/libzecale/tests/circuits/group_variable_gadgets_test.cpp
+++ b/libzecale/tests/circuits/group_variable_gadgets_test.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2020 Clearmatics Technologies Ltd
+// Copyright (c) 2015-2021 Clearmatics Technologies Ltd
 //
 // SPDX-License-Identifier: LGPL-3.0+
 

--- a/libzecale/tests/circuits/group_variable_gadgets_test.cpp
+++ b/libzecale/tests/circuits/group_variable_gadgets_test.cpp
@@ -218,6 +218,34 @@ TEST(PointMultiplicationGadgetsTest, G2MulByConstScalarWithKnownResult)
     }
 }
 
+TEST(PointMultiplicationGadgetsTest, G2EqualityGadget)
+{
+    // Compute inputs and results
+    const libff::G2<npp> P_val = libff::Fr<npp>(13) * libff::G2<npp>::one();
+    const libff::G2<npp> Q_val = libff::Fr<npp>(12) * libff::G2<npp>::one();
+
+    // Circuit
+    libsnark::protoboard<libff::Fr<wpp>> pb;
+    libsnark::G2_variable<wpp> P(pb, "P");
+    libsnark::G2_variable<wpp> Q(pb, "Q");
+    libzecale::G2_equality_gadget<wpp> equality_gadget(
+        pb, P, Q, "equality_gadget");
+
+    equality_gadget.generate_r1cs_constraints();
+
+    // P == Q case
+    P.generate_r1cs_witness(P_val);
+    Q.generate_r1cs_witness(P_val);
+    equality_gadget.generate_r1cs_witness();
+    ASSERT_TRUE(pb.is_satisfied());
+
+    // P != Q case
+    P.generate_r1cs_witness(P_val);
+    Q.generate_r1cs_witness(Q_val);
+    equality_gadget.generate_r1cs_witness();
+    ASSERT_FALSE(pb.is_satisfied());
+}
+
 } // namespace
 
 int main(int argc, char **argv)

--- a/libzecale/tests/circuits/group_variable_gadgets_test.cpp
+++ b/libzecale/tests/circuits/group_variable_gadgets_test.cpp
@@ -1,0 +1,107 @@
+// Copyright (c) 2015-2020 Clearmatics Technologies Ltd
+//
+// SPDX-License-Identifier: LGPL-3.0+
+
+#include "libzecale/circuits/pairing/bw6_761_pairing_params.hpp"
+#include "libzecale/circuits/pairing/group_variable_gadgets.hpp"
+
+#include <gtest/gtest.h>
+#include <libff/algebra/curves/bls12_377/bls12_377_pp.hpp>
+#include <libff/algebra/curves/bw6_761/bw6_761_pp.hpp>
+
+using wpp = libff::bw6_761_pp;
+using npp = libsnark::other_curve<wpp>;
+
+namespace
+{
+
+TEST(PointMultiplicationGadgetsTest, G1MulByConstScalar)
+{
+    // Compute inputs and results
+    const libff::G1<npp> P_val = libff::Fr<npp>(13) * libff::G1<npp>::one();
+    const libff::Fr<npp> scalar_val_a = libff::Fr<npp>(127);
+    const libff::G1<npp> expect_result_val_a = scalar_val_a * P_val;
+    const libff::Fr<npp> scalar_val_b = libff::Fr<npp>(122);
+    const libff::G1<npp> expect_result_val_b = scalar_val_b * P_val;
+    // Circuit
+    libsnark::protoboard<libff::Fr<wpp>> pb;
+    libsnark::G1_variable<wpp> P(pb, "P");
+    libsnark::G1_variable<wpp> result_a(pb, "result");
+    libzecale::G1_mul_by_const_scalar_gadget<wpp, libff::Fr<npp>::num_limbs>
+        mul_gadget_a(pb, scalar_val_a.as_bigint(), P, result_a, "mul_gadget_a");
+    libsnark::G1_variable<wpp> result_b(pb, "result");
+    libzecale::G1_mul_by_const_scalar_gadget<wpp, libff::Fr<npp>::num_limbs>
+        mul_gadget_b(pb, scalar_val_b.as_bigint(), P, result_b, "mul_gadget_b");
+
+    mul_gadget_a.generate_r1cs_constraints();
+    mul_gadget_b.generate_r1cs_constraints();
+
+    P.generate_r1cs_witness(P_val);
+    mul_gadget_a.generate_r1cs_witness();
+    mul_gadget_b.generate_r1cs_witness();
+
+    ASSERT_TRUE(pb.is_satisfied());
+
+    const libff::G1<npp> result_a_val =
+        libzecale::g1_variable_get_element(result_a);
+    ASSERT_EQ(expect_result_val_a, result_a_val);
+    const libff::G1<npp> result_b_val =
+        libzecale::g1_variable_get_element(result_b);
+    ASSERT_EQ(expect_result_val_b, result_b_val);
+}
+
+TEST(PointMultiplicationGadgetsTest, G1MulByConstScalarWithKnownResult)
+{
+    // Compute inputs and results
+    const libff::G1<npp> P_val = libff::Fr<npp>(13) * libff::G1<npp>::one();
+    const libff::G1<npp> Q_val = libff::Fr<npp>(12) * libff::G1<npp>::one();
+    const libff::Fr<npp> scalar_val = libff::Fr<npp>(127);
+    const libff::G1<npp> result_val = scalar_val * P_val;
+
+    // Valid case
+    {
+        // Circuit
+        libsnark::protoboard<libff::Fr<wpp>> pb;
+        libsnark::G1_variable<wpp> P(pb, "P");
+        libsnark::G1_variable<wpp> result(pb, "result");
+        libzecale::G1_mul_by_const_scalar_gadget<wpp, libff::Fr<npp>::num_limbs>
+            mul_gadget(pb, scalar_val.as_bigint(), P, result, "mul_gadget");
+
+        mul_gadget.generate_r1cs_constraints();
+
+        // Witness the input, gadget AND output
+        P.generate_r1cs_witness(P_val);
+        mul_gadget.generate_r1cs_witness();
+        result.generate_r1cs_witness(result_val);
+        ASSERT_TRUE(pb.is_satisfied());
+    }
+
+    // Invalid case. Use the gadget to ensure a specific value in the result,
+    // by assigning the expected value after the gadget.
+    {
+        // Circuit
+        libsnark::protoboard<libff::Fr<wpp>> pb;
+        libsnark::G1_variable<wpp> P(pb, "P");
+        libsnark::G1_variable<wpp> result(pb, "result");
+        libzecale::G1_mul_by_const_scalar_gadget<wpp, libff::Fr<npp>::num_limbs>
+            mul_gadget(pb, scalar_val.as_bigint(), P, result, "mul_gadget");
+
+        mul_gadget.generate_r1cs_constraints();
+
+        // Witness the input, gadget AND (invalid) output
+        P.generate_r1cs_witness(Q_val);
+        mul_gadget.generate_r1cs_witness();
+        result.generate_r1cs_witness(result_val);
+        ASSERT_FALSE(pb.is_satisfied());
+    }
+}
+
+} // namespace
+
+int main(int argc, char **argv)
+{
+    libff::bls12_377_pp::init_public_params();
+    libff::bw6_761_pp::init_public_params();
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/libzecale/tests/circuits/group_variable_gadgets_test.cpp
+++ b/libzecale/tests/circuits/group_variable_gadgets_test.cpp
@@ -96,6 +96,32 @@ TEST(PointMultiplicationGadgetsTest, G1MulByConstScalarWithKnownResult)
     }
 }
 
+TEST(PointMultiplicationGadgetsTest, G2AddGadget)
+{
+    // Compute inputs and results
+    const libff::G2<npp> A_val = libff::Fr<npp>(13) * libff::G2<npp>::one();
+    const libff::G2<npp> B_val = libff::Fr<npp>(12) * libff::G2<npp>::one();
+    const libff::G2<npp> expect_C_val =
+        libff::Fr<npp>(12 + 13) * libff::G2<npp>::one();
+    ASSERT_EQ(expect_C_val, A_val + B_val);
+
+    libsnark::protoboard<libff::Fr<wpp>> pb;
+    libsnark::G2_variable<wpp> A(pb, "A");
+    libsnark::G2_variable<wpp> B(pb, "B");
+    libsnark::G2_variable<wpp> C(pb, "C");
+    libzecale::G2_add_gadget<wpp> add_gadget(pb, A, B, C, "add_gadget");
+
+    add_gadget.generate_r1cs_constraints();
+
+    A.generate_r1cs_witness(A_val);
+    B.generate_r1cs_witness(B_val);
+    add_gadget.generate_r1cs_witness();
+
+    const libff::G2<npp> C_val = libzecale::g2_variable_get_element(C);
+    ASSERT_TRUE(pb.is_satisfied());
+    ASSERT_EQ(expect_C_val, C_val);
+}
+
 } // namespace
 
 int main(int argc, char **argv)

--- a/libzecale/tests/circuits/group_variable_gadgets_test.cpp
+++ b/libzecale/tests/circuits/group_variable_gadgets_test.cpp
@@ -122,6 +122,29 @@ TEST(PointMultiplicationGadgetsTest, G2AddGadget)
     ASSERT_EQ(expect_C_val, C_val);
 }
 
+TEST(PointMultiplicationGadgetsTest, G2DblGadget)
+{
+    // Compute inputs and results
+    const libff::G2<npp> A_val = libff::Fr<npp>(13) * libff::G2<npp>::one();
+    const libff::G2<npp> expect_B_val =
+        libff::Fr<npp>(13 + 13) * libff::G2<npp>::one();
+    ASSERT_EQ(A_val.dbl(), expect_B_val);
+
+    libsnark::protoboard<libff::Fr<wpp>> pb;
+    libsnark::G2_variable<wpp> A(pb, "A");
+    libsnark::G2_variable<wpp> B(pb, "B");
+    libzecale::G2_dbl_gadget<wpp> dbl_gadget(pb, A, B, "dbl_gadget");
+
+    dbl_gadget.generate_r1cs_constraints();
+
+    A.generate_r1cs_witness(A_val);
+    dbl_gadget.generate_r1cs_witness();
+
+    const libff::G2<npp> B_val = libzecale::g2_variable_get_element(B);
+    ASSERT_TRUE(pb.is_satisfied());
+    ASSERT_EQ(expect_B_val, B_val);
+}
+
 } // namespace
 
 int main(int argc, char **argv)


### PR DESCRIPTION
Gadgets to perform subgroup membership checks on BLS12-377 curve points.
See: clearmatics/libff#31

NOTE: Includes libff, libsnark and zeth updates.

Before merging:
- [x] Merge clearmatics/libff#31
- [x] Merge clearmatics/libsnark#15
- [x] Merge clearmatics/zeth#325
- [x] Wait for zeth release?