### PR TITLE
Enable membership check gadgets in aggregator circuit (depends on #57)

### DIFF
--- a/libzecale/circuits/aggregator_gadget.tcc
+++ b/libzecale/circuits/aggregator_gadget.tcc
@@ -21,7 +21,7 @@ aggregator_gadget<wppT, nverifierT, NumProofs>::aggregator_gadget(
         &proof_results,
     const std::string &annotation_prefix)
     : libsnark::gadget<libff::Fr<wppT>>(pb, annotation_prefix)
-    , num_inputs_per_nested_proof(vk.input_size)
+    , num_inputs_per_nested_proof(vk._input_size)
     , nested_primary_inputs(inputs)
 {
     // Assert that a single input of a nested proof (element of

--- a/libzecale/circuits/groth16_verifier/r1cs_gg_ppzksnark_verifier_gadget.hpp
+++ b/libzecale/circuits/groth16_verifier/r1cs_gg_ppzksnark_verifier_gadget.hpp
@@ -30,18 +30,18 @@ class r1cs_gg_ppzksnark_proof_variable : public libsnark::gadget<libff::Fr<ppT>>
 public:
     typedef libff::Fr<ppT> FieldT;
 
-    std::shared_ptr<libsnark::G1_variable<ppT>> g_A;
-    std::shared_ptr<libsnark::G2_variable<ppT>> g_B;
-    std::shared_ptr<libsnark::G1_variable<ppT>> g_C;
+    std::shared_ptr<libsnark::G1_variable<ppT>> _g_A;
+    std::shared_ptr<libsnark::G2_variable<ppT>> _g_B;
+    std::shared_ptr<libsnark::G1_variable<ppT>> _g_C;
 
-    std::vector<std::shared_ptr<libsnark::G1_variable<ppT>>> all_G1_vars;
-    std::vector<std::shared_ptr<libsnark::G2_variable<ppT>>> all_G2_vars;
+    std::vector<std::shared_ptr<libsnark::G1_variable<ppT>>> _all_G1_vars;
+    std::vector<std::shared_ptr<libsnark::G2_variable<ppT>>> _all_G2_vars;
 
     std::vector<std::shared_ptr<libsnark::G1_checker_gadget<ppT>>>
-        all_G1_checkers;
-    std::shared_ptr<libsnark::G2_checker_gadget<ppT>> G2_checker;
+        _all_G1_checkers;
+    std::shared_ptr<libsnark::G2_checker_gadget<ppT>> _G2_checker;
 
-    libsnark::pb_variable_array<FieldT> proof_contents;
+    libsnark::pb_variable_array<FieldT> _proof_contents;
 
     r1cs_gg_ppzksnark_proof_variable(
         libsnark::protoboard<FieldT> &pb, const std::string &annotation_prefix);
@@ -58,17 +58,17 @@ class r1cs_gg_ppzksnark_verification_key_variable
 public:
     typedef libff::Fr<ppT> FieldT;
 
-    std::shared_ptr<libsnark::G1_variable<ppT>> alpha_g1;
-    std::shared_ptr<libsnark::G2_variable<ppT>> beta_g2;
-    std::shared_ptr<libsnark::G2_variable<ppT>> delta_g2;
-    std::shared_ptr<libsnark::G1_variable<ppT>> encoded_ABC_base;
-    std::vector<std::shared_ptr<libsnark::G1_variable<ppT>>> ABC_g1;
+    std::shared_ptr<libsnark::G1_variable<ppT>> _alpha_g1;
+    std::shared_ptr<libsnark::G2_variable<ppT>> _beta_g2;
+    std::shared_ptr<libsnark::G2_variable<ppT>> _delta_g2;
+    std::shared_ptr<libsnark::G1_variable<ppT>> _encoded_ABC_base;
+    std::vector<std::shared_ptr<libsnark::G1_variable<ppT>>> _ABC_g1;
 
-    libsnark::pb_variable_array<FieldT> all_bits;
-    libsnark::pb_linear_combination_array<FieldT> all_vars;
-    size_t input_size;
+    libsnark::pb_variable_array<FieldT> _all_bits;
+    libsnark::pb_linear_combination_array<FieldT> _all_vars;
+    size_t _input_size;
 
-    std::shared_ptr<libsnark::multipacking_gadget<FieldT>> packer;
+    std::shared_ptr<libsnark::multipacking_gadget<FieldT>> _packer;
 
     // Unfortunately, g++ 4.9 and g++ 5.0 have a bug related to
     // incorrect inlining of small functions:
@@ -104,13 +104,13 @@ class r1cs_gg_ppzksnark_preprocessed_r1cs_gg_ppzksnark_verification_key_variable
 public:
     typedef libff::Fr<ppT> FieldT;
 
-    std::shared_ptr<G1_precomputation<ppT>> vk_alpha_g1_precomp;
-    std::shared_ptr<G2_precomputation<ppT>> vk_generator_g2_precomp;
-    std::shared_ptr<G2_precomputation<ppT>> vk_beta_g2_precomp;
-    std::shared_ptr<G2_precomputation<ppT>> vk_delta_g2_precomp;
+    std::shared_ptr<G1_precomputation<ppT>> _vk_alpha_g1_precomp;
+    std::shared_ptr<G2_precomputation<ppT>> _vk_generator_g2_precomp;
+    std::shared_ptr<G2_precomputation<ppT>> _vk_beta_g2_precomp;
+    std::shared_ptr<G2_precomputation<ppT>> _vk_delta_g2_precomp;
 
-    std::shared_ptr<libsnark::G1_variable<ppT>> encoded_ABC_base;
-    std::vector<std::shared_ptr<libsnark::G1_variable<ppT>>> ABC_g1;
+    std::shared_ptr<libsnark::G1_variable<ppT>> _encoded_ABC_base;
+    std::vector<std::shared_ptr<libsnark::G1_variable<ppT>>> _ABC_g1;
 
     r1cs_gg_ppzksnark_preprocessed_r1cs_gg_ppzksnark_verification_key_variable();
     r1cs_gg_ppzksnark_preprocessed_r1cs_gg_ppzksnark_verification_key_variable(
@@ -127,15 +127,15 @@ class r1cs_gg_ppzksnark_verifier_process_vk_gadget
 public:
     typedef libff::Fr<ppT> FieldT;
 
-    std::shared_ptr<G1_precompute_gadget<ppT>> compute_vk_alpha_g1_precomp;
+    std::shared_ptr<G1_precompute_gadget<ppT>> _compute_vk_alpha_g1_precomp;
 
-    std::shared_ptr<G2_precompute_gadget<ppT>> compute_vk_generator_g2_precomp;
-    std::shared_ptr<G2_precompute_gadget<ppT>> compute_vk_beta_g2_precomp;
-    std::shared_ptr<G2_precompute_gadget<ppT>> compute_vk_delta_g2_precomp;
+    std::shared_ptr<G2_precompute_gadget<ppT>> _compute_vk_generator_g2_precomp;
+    std::shared_ptr<G2_precompute_gadget<ppT>> _compute_vk_beta_g2_precomp;
+    std::shared_ptr<G2_precompute_gadget<ppT>> _compute_vk_delta_g2_precomp;
 
-    r1cs_gg_ppzksnark_verification_key_variable<ppT> vk;
+    r1cs_gg_ppzksnark_verification_key_variable<ppT> _vk;
     r1cs_gg_ppzksnark_preprocessed_r1cs_gg_ppzksnark_verification_key_variable<
-        ppT> &pvk;
+        ppT> &_pvk;
 
     r1cs_gg_ppzksnark_verifier_process_vk_gadget(
         libsnark::protoboard<FieldT> &pb,
@@ -156,29 +156,29 @@ public:
 
     r1cs_gg_ppzksnark_preprocessed_r1cs_gg_ppzksnark_verification_key_variable<
         ppT>
-        pvk;
+        _pvk;
 
-    libsnark::pb_variable_array<FieldT> input;
-    size_t elt_size;
-    r1cs_gg_ppzksnark_proof_variable<ppT> proof;
+    libsnark::pb_variable_array<FieldT> _input;
+    size_t _elt_size;
+    r1cs_gg_ppzksnark_proof_variable<ppT> _proof;
     // The `result` variable should be allocated outside of this circuit
-    libsnark::pb_variable<FieldT> result;
-    const size_t input_len;
+    libsnark::pb_variable<FieldT> _result;
+    const size_t _input_len;
 
-    std::shared_ptr<libsnark::G1_variable<ppT>> acc;
-    std::shared_ptr<libsnark::G1_multiscalar_mul_gadget<ppT>> accumulate_input;
+    std::shared_ptr<libsnark::G1_variable<ppT>> _acc;
+    std::shared_ptr<libsnark::G1_multiscalar_mul_gadget<ppT>> _accumulate_input;
 
-    std::shared_ptr<G1_precomputation<ppT>> proof_g_A_precomp;
-    std::shared_ptr<G2_precomputation<ppT>> proof_g_B_precomp;
-    std::shared_ptr<G1_precomputation<ppT>> proof_g_C_precomp;
-    std::shared_ptr<G1_precomputation<ppT>> acc_precomp;
+    std::shared_ptr<G1_precomputation<ppT>> _proof_g_A_precomp;
+    std::shared_ptr<G2_precomputation<ppT>> _proof_g_B_precomp;
+    std::shared_ptr<G1_precomputation<ppT>> _proof_g_C_precomp;
+    std::shared_ptr<G1_precomputation<ppT>> _acc_precomp;
 
-    std::shared_ptr<G1_precompute_gadget<ppT>> compute_proof_g_A_precomp;
-    std::shared_ptr<G2_precompute_gadget<ppT>> compute_proof_g_B_precomp;
-    std::shared_ptr<G1_precompute_gadget<ppT>> compute_proof_g_C_precomp;
-    std::shared_ptr<G1_precompute_gadget<ppT>> compute_acc_precomp;
+    std::shared_ptr<G1_precompute_gadget<ppT>> _compute_proof_g_A_precomp;
+    std::shared_ptr<G2_precompute_gadget<ppT>> _compute_proof_g_B_precomp;
+    std::shared_ptr<G1_precompute_gadget<ppT>> _compute_proof_g_C_precomp;
+    std::shared_ptr<G1_precompute_gadget<ppT>> _compute_acc_precomp;
 
-    std::shared_ptr<check_e_equals_eee_gadget<ppT>> check_QAP_valid;
+    std::shared_ptr<check_e_equals_eee_gadget<ppT>> _check_QAP_valid;
 
     r1cs_gg_ppzksnark_online_verifier_gadget(
         libsnark::protoboard<FieldT> &pb,
@@ -203,11 +203,11 @@ public:
     std::shared_ptr<
         r1cs_gg_ppzksnark_preprocessed_r1cs_gg_ppzksnark_verification_key_variable<
             ppT>>
-        pvk;
+        _pvk;
     std::shared_ptr<r1cs_gg_ppzksnark_verifier_process_vk_gadget<ppT>>
-        compute_pvk;
+        _compute_pvk;
     std::shared_ptr<r1cs_gg_ppzksnark_online_verifier_gadget<ppT>>
-        online_verifier;
+        _online_verifier;
 
     r1cs_gg_ppzksnark_verifier_gadget(
         libsnark::protoboard<FieldT> &pb,

--- a/libzecale/circuits/groth16_verifier/r1cs_gg_ppzksnark_verifier_gadget.hpp
+++ b/libzecale/circuits/groth16_verifier/r1cs_gg_ppzksnark_verifier_gadget.hpp
@@ -37,9 +37,8 @@ public:
     std::vector<std::shared_ptr<libsnark::G1_variable<ppT>>> _all_G1_vars;
     std::vector<std::shared_ptr<libsnark::G2_variable<ppT>>> _all_G2_vars;
 
-    std::vector<std::shared_ptr<libsnark::G1_checker_gadget<ppT>>>
-        _all_G1_checkers;
-    std::shared_ptr<libsnark::G2_checker_gadget<ppT>> _G2_checker;
+    std::vector<std::shared_ptr<G1_checker<ppT>>> _all_G1_checkers;
+    std::shared_ptr<G2_checker<ppT>> _G2_checker;
 
     libsnark::pb_variable_array<FieldT> _proof_contents;
 

--- a/libzecale/circuits/groth16_verifier/r1cs_gg_ppzksnark_verifier_gadget.tcc
+++ b/libzecale/circuits/groth16_verifier/r1cs_gg_ppzksnark_verifier_gadget.tcc
@@ -5,6 +5,8 @@
 #ifndef __ZECALE_CIRCUITS_GROTH16_VERIFIER_R1CS_GG_PPZKSNARK_VERIFIER_GADGET_TCC__
 #define __ZECALE_CIRCUITS_GROTH16_VERIFIER_R1CS_GG_PPZKSNARK_VERIFIER_GADGET_TCC__
 
+#include "libzecale/circuits/groth16_verifier/r1cs_gg_ppzksnark_verifier_gadget.hpp"
+
 #include <libsnark/gadgetlib1/constraint_profiling.hpp>
 
 namespace libzecale
@@ -22,40 +24,40 @@ r1cs_gg_ppzksnark_proof_variable<ppT>::r1cs_gg_ppzksnark_proof_variable(
     const size_t num_G2 = 1;
 #endif
 
-    g_A.reset(
+    _g_A.reset(
         new libsnark::G1_variable<ppT>(pb, FMT(annotation_prefix, " g_A")));
-    g_B.reset(
+    _g_B.reset(
         new libsnark::G2_variable<ppT>(pb, FMT(annotation_prefix, " g_B")));
-    g_C.reset(
+    _g_C.reset(
         new libsnark::G1_variable<ppT>(pb, FMT(annotation_prefix, " g_C")));
 
-    all_G1_vars = {g_A, g_C};
-    all_G2_vars = {g_B};
+    _all_G1_vars = {_g_A, _g_C};
+    _all_G2_vars = {_g_B};
 
-    all_G1_checkers.resize(all_G1_vars.size());
+    _all_G1_checkers.resize(_all_G1_vars.size());
 
-    for (size_t i = 0; i < all_G1_vars.size(); ++i) {
-        all_G1_checkers[i].reset(new libsnark::G1_checker_gadget<ppT>(
+    for (size_t i = 0; i < _all_G1_vars.size(); ++i) {
+        _all_G1_checkers[i].reset(new libsnark::G1_checker_gadget<ppT>(
             pb,
-            *all_G1_vars[i],
+            *_all_G1_vars[i],
             FMT(annotation_prefix, " all_G1_checkers_%zu", i)));
     }
 
-    G2_checker.reset(new libsnark::G2_checker_gadget<ppT>(
-        pb, *g_B, FMT(annotation_prefix, " G2_checker")));
+    _G2_checker.reset(new libsnark::G2_checker_gadget<ppT>(
+        pb, *_g_B, FMT(annotation_prefix, " G2_checker")));
 
-    assert(all_G1_vars.size() == num_G1);
-    assert(all_G2_vars.size() == num_G2);
+    assert(_all_G1_vars.size() == num_G1);
+    assert(_all_G2_vars.size() == num_G2);
 }
 
 template<typename ppT>
 void r1cs_gg_ppzksnark_proof_variable<ppT>::generate_r1cs_constraints()
 {
-    for (auto &G1_checker : all_G1_checkers) {
+    for (auto &G1_checker : _all_G1_checkers) {
         G1_checker->generate_r1cs_constraints();
     }
 
-    G2_checker->generate_r1cs_constraints();
+    _G2_checker->generate_r1cs_constraints();
 }
 
 template<typename ppT>
@@ -68,22 +70,22 @@ void r1cs_gg_ppzksnark_proof_variable<ppT>::generate_r1cs_witness(
     G1_elems = {proof.g_A, proof.g_C};
     G2_elems = {proof.g_B};
 
-    assert(G1_elems.size() == all_G1_vars.size());
-    assert(G2_elems.size() == all_G2_vars.size());
+    assert(G1_elems.size() == _all_G1_vars.size());
+    assert(G2_elems.size() == _all_G2_vars.size());
 
     for (size_t i = 0; i < G1_elems.size(); ++i) {
-        all_G1_vars[i]->generate_r1cs_witness(G1_elems[i]);
+        _all_G1_vars[i]->generate_r1cs_witness(G1_elems[i]);
     }
 
     for (size_t i = 0; i < G2_elems.size(); ++i) {
-        all_G2_vars[i]->generate_r1cs_witness(G2_elems[i]);
+        _all_G2_vars[i]->generate_r1cs_witness(G2_elems[i]);
     }
 
-    for (auto &G1_checker : all_G1_checkers) {
+    for (auto &G1_checker : _all_G1_checkers) {
         G1_checker->generate_r1cs_witness();
     }
 
-    G2_checker->generate_r1cs_witness();
+    _G2_checker->generate_r1cs_witness();
 }
 
 template<typename ppT> size_t r1cs_gg_ppzksnark_proof_variable<ppT>::size()
@@ -103,47 +105,51 @@ r1cs_gg_ppzksnark_verification_key_variable<ppT>::
         const size_t input_size,
         const std::string &annotation_prefix)
     : libsnark::gadget<FieldT>(pb, annotation_prefix)
-    , alpha_g1(new libsnark::G1_variable<ppT>(
+    , _alpha_g1(new libsnark::G1_variable<ppT>(
           pb, FMT(annotation_prefix, " alpha_g1")))
-    , beta_g2(new libsnark::G2_variable<ppT>(
+    , _beta_g2(new libsnark::G2_variable<ppT>(
           pb, FMT(annotation_prefix, " beta_g2")))
-    , delta_g2(new libsnark::G2_variable<ppT>(
+    , _delta_g2(new libsnark::G2_variable<ppT>(
           pb, FMT(annotation_prefix, " delta_g2")))
-    , encoded_ABC_base(new libsnark::G1_variable<ppT>(
+    , _encoded_ABC_base(new libsnark::G1_variable<ppT>(
           pb, FMT(annotation_prefix, " encoded_ABC_base")))
-    , all_bits(all_bits)
-    , input_size(input_size)
+    , _all_bits(all_bits)
+    , _input_size(input_size)
 {
-    assert(all_bits.size() == size_in_bits(input_size));
+    assert(_all_bits.size() == size_in_bits(input_size));
 
     // Populate all_vars with all elements.
-    all_vars.insert(
-        all_vars.end(), alpha_g1->all_vars.begin(), alpha_g1->all_vars.end());
-    all_vars.insert(
-        all_vars.end(), beta_g2->all_vars.begin(), beta_g2->all_vars.end());
-    all_vars.insert(
-        all_vars.end(), delta_g2->all_vars.begin(), delta_g2->all_vars.end());
-    all_vars.insert(
-        all_vars.end(),
-        encoded_ABC_base->all_vars.begin(),
-        encoded_ABC_base->all_vars.end());
+    _all_vars.insert(
+        _all_vars.end(),
+        _alpha_g1->all_vars.begin(),
+        _alpha_g1->all_vars.end());
+    _all_vars.insert(
+        _all_vars.end(), _beta_g2->all_vars.begin(), _beta_g2->all_vars.end());
+    _all_vars.insert(
+        _all_vars.end(),
+        _delta_g2->all_vars.begin(),
+        _delta_g2->all_vars.end());
+    _all_vars.insert(
+        _all_vars.end(),
+        _encoded_ABC_base->all_vars.begin(),
+        _encoded_ABC_base->all_vars.end());
 
     // Allocate variables for ABC_g1 elements (and add to all_vars list)
-    ABC_g1.reserve(input_size);
-    for (size_t i = 0; i < input_size; ++i) {
-        ABC_g1.emplace_back(new libsnark::G1_variable<ppT>(
+    _ABC_g1.reserve(input_size);
+    for (size_t i = 0; i < _input_size; ++i) {
+        _ABC_g1.emplace_back(new libsnark::G1_variable<ppT>(
             pb, FMT(annotation_prefix, " ABC_g1[%zu]", i)));
-        const libsnark::G1_variable<ppT> &ivar = *(ABC_g1.back());
-        all_vars.insert(
-            all_vars.end(), ivar.all_vars.begin(), ivar.all_vars.end());
+        const libsnark::G1_variable<ppT> &ivar = *(_ABC_g1.back());
+        _all_vars.insert(
+            _all_vars.end(), ivar.all_vars.begin(), ivar.all_vars.end());
     }
     assert(
-        all_vars.size() == size_in_bits(input_size) / FieldT::size_in_bits());
+        _all_vars.size() == size_in_bits(_input_size) / FieldT::size_in_bits());
 
-    packer.reset(new libsnark::multipacking_gadget<FieldT>(
+    _packer.reset(new libsnark::multipacking_gadget<FieldT>(
         pb,
-        all_bits,
-        all_vars,
+        _all_bits,
+        _all_vars,
         FieldT::size_in_bits(),
         FMT(annotation_prefix, " packer")));
 }
@@ -152,38 +158,38 @@ template<typename ppT>
 void r1cs_gg_ppzksnark_verification_key_variable<
     ppT>::generate_r1cs_constraints(const bool enforce_bitness)
 {
-    packer->generate_r1cs_constraints(enforce_bitness);
+    _packer->generate_r1cs_constraints(enforce_bitness);
 }
 
 template<typename ppT>
 void r1cs_gg_ppzksnark_verification_key_variable<ppT>::generate_r1cs_witness(
     const libsnark::r1cs_gg_ppzksnark_verification_key<other_curve<ppT>> &vk)
 {
-    alpha_g1->generate_r1cs_witness(vk.alpha_g1);
-    beta_g2->generate_r1cs_witness(vk.beta_g2);
-    delta_g2->generate_r1cs_witness(vk.delta_g2);
-    encoded_ABC_base->generate_r1cs_witness(vk.ABC_g1.first);
-    for (size_t i = 0; i < input_size; ++i) {
+    _alpha_g1->generate_r1cs_witness(vk.alpha_g1);
+    _beta_g2->generate_r1cs_witness(vk.beta_g2);
+    _delta_g2->generate_r1cs_witness(vk.delta_g2);
+    _encoded_ABC_base->generate_r1cs_witness(vk.ABC_g1.first);
+    for (size_t i = 0; i < _input_size; ++i) {
         assert(vk.ABC_g1.rest.indices[i] == i);
-        ABC_g1[i]->generate_r1cs_witness(vk.ABC_g1.rest.values[i]);
+        _ABC_g1[i]->generate_r1cs_witness(vk.ABC_g1.rest.values[i]);
     }
 
-    packer->generate_r1cs_witness_from_packed();
+    _packer->generate_r1cs_witness_from_packed();
 }
 
 template<typename ppT>
 void r1cs_gg_ppzksnark_verification_key_variable<ppT>::generate_r1cs_witness(
     const libff::bit_vector &vk_bits)
 {
-    all_bits.fill_with_bits(this->pb, vk_bits);
-    packer->generate_r1cs_witness_from_bits();
+    _all_bits.fill_with_bits(this->pb, vk_bits);
+    _packer->generate_r1cs_witness_from_bits();
 }
 
 template<typename ppT>
 libff::bit_vector r1cs_gg_ppzksnark_verification_key_variable<ppT>::get_bits()
     const
 {
-    return all_bits.get_bits(this->pb);
+    return _all_bits.get_bits(this->pb);
 }
 
 template<typename ppT>
@@ -234,27 +240,27 @@ r1cs_gg_ppzksnark_preprocessed_r1cs_gg_ppzksnark_verification_key_variable<
             &r1cs_vk,
         const std::string &annotation_prefix)
 {
-    encoded_ABC_base.reset(new libsnark::G1_variable<ppT>(
+    _encoded_ABC_base.reset(new libsnark::G1_variable<ppT>(
         pb, r1cs_vk.ABC_g1.first, FMT(annotation_prefix, " encoded_ABC_base")));
-    ABC_g1.resize(r1cs_vk.ABC_g1.rest.indices.size());
+    _ABC_g1.resize(r1cs_vk.ABC_g1.rest.indices.size());
     for (size_t i = 0; i < r1cs_vk.ABC_g1.rest.indices.size(); ++i) {
         assert(r1cs_vk.ABC_g1.rest.indices[i] == i);
-        ABC_g1[i].reset(new libsnark::G1_variable<ppT>(
+        _ABC_g1[i].reset(new libsnark::G1_variable<ppT>(
             pb,
             r1cs_vk.ABC_g1.rest.values[i],
             FMT(annotation_prefix, " ABC_g1[%zu]", i)));
     }
 
-    vk_alpha_g1_precomp.reset(new G1_precomputation<ppT>(
+    _vk_alpha_g1_precomp.reset(new G1_precomputation<ppT>(
         pb, r1cs_vk.alpha_g1, FMT(annotation_prefix, " vk_alpha_g1_precomp")));
 
-    vk_generator_g2_precomp.reset(new G2_precomputation<ppT>(
+    _vk_generator_g2_precomp.reset(new G2_precomputation<ppT>(
         pb,
         libff::G2<other_curve<ppT>>::one(),
         FMT(annotation_prefix, " vk_generator_g2_precomp")));
-    vk_beta_g2_precomp.reset(new G2_precomputation<ppT>(
+    _vk_beta_g2_precomp.reset(new G2_precomputation<ppT>(
         pb, r1cs_vk.beta_g2, FMT(annotation_prefix, " vk_beta_g2_precomp")));
-    vk_delta_g2_precomp.reset(new G2_precomputation<ppT>(
+    _vk_delta_g2_precomp.reset(new G2_precomputation<ppT>(
         pb, r1cs_vk.delta_g2, FMT(annotation_prefix, " vk_delta_g2_precomp")));
 }
 
@@ -266,36 +272,36 @@ r1cs_gg_ppzksnark_verifier_process_vk_gadget<ppT>::
         r1cs_gg_ppzksnark_preprocessed_r1cs_gg_ppzksnark_verification_key_variable<
             ppT> &pvk,
         const std::string &annotation_prefix)
-    : libsnark::gadget<FieldT>(pb, annotation_prefix), vk(vk), pvk(pvk)
+    : libsnark::gadget<FieldT>(pb, annotation_prefix), _vk(vk), _pvk(pvk)
 {
-    pvk.encoded_ABC_base = vk.encoded_ABC_base;
-    pvk.ABC_g1 = vk.ABC_g1;
+    _pvk._encoded_ABC_base = vk._encoded_ABC_base;
+    _pvk._ABC_g1 = vk._ABC_g1;
 
-    pvk.vk_alpha_g1_precomp.reset(new G1_precomputation<ppT>());
+    _pvk._vk_alpha_g1_precomp.reset(new G1_precomputation<ppT>());
 
-    pvk.vk_generator_g2_precomp.reset(new G2_precomputation<ppT>());
-    pvk.vk_beta_g2_precomp.reset(new G2_precomputation<ppT>());
-    pvk.vk_delta_g2_precomp.reset(new G2_precomputation<ppT>());
+    _pvk._vk_generator_g2_precomp.reset(new G2_precomputation<ppT>());
+    _pvk._vk_beta_g2_precomp.reset(new G2_precomputation<ppT>());
+    _pvk._vk_delta_g2_precomp.reset(new G2_precomputation<ppT>());
 
-    compute_vk_alpha_g1_precomp.reset(new G1_precompute_gadget<ppT>(
+    _compute_vk_alpha_g1_precomp.reset(new G1_precompute_gadget<ppT>(
         pb,
-        *vk.alpha_g1,
-        *pvk.vk_alpha_g1_precomp,
+        *vk._alpha_g1,
+        *pvk._vk_alpha_g1_precomp,
         FMT(annotation_prefix, " compute_vk_alpha_g1_precomp")));
 
-    pvk.vk_generator_g2_precomp.reset(new G2_precomputation<ppT>(
+    _pvk._vk_generator_g2_precomp.reset(new G2_precomputation<ppT>(
         pb,
         libff::G2<other_curve<ppT>>::one(),
         FMT(annotation_prefix, " vk_generator_g2_precomp")));
-    compute_vk_beta_g2_precomp.reset(new G2_precompute_gadget<ppT>(
+    _compute_vk_beta_g2_precomp.reset(new G2_precompute_gadget<ppT>(
         pb,
-        *vk.beta_g2,
-        *pvk.vk_beta_g2_precomp,
+        *vk._beta_g2,
+        *pvk._vk_beta_g2_precomp,
         FMT(annotation_prefix, " compute_vk_beta_g2_precomp")));
-    compute_vk_delta_g2_precomp.reset(new G2_precompute_gadget<ppT>(
+    _compute_vk_delta_g2_precomp.reset(new G2_precompute_gadget<ppT>(
         pb,
-        *vk.delta_g2,
-        *pvk.vk_delta_g2_precomp,
+        *vk._delta_g2,
+        *pvk._vk_delta_g2_precomp,
         FMT(annotation_prefix, " compute_vk_delta_g2_precomp")));
 }
 
@@ -303,19 +309,19 @@ template<typename ppT>
 void r1cs_gg_ppzksnark_verifier_process_vk_gadget<
     ppT>::generate_r1cs_constraints()
 {
-    compute_vk_alpha_g1_precomp->generate_r1cs_constraints();
+    _compute_vk_alpha_g1_precomp->generate_r1cs_constraints();
 
-    compute_vk_beta_g2_precomp->generate_r1cs_constraints();
-    compute_vk_delta_g2_precomp->generate_r1cs_constraints();
+    _compute_vk_beta_g2_precomp->generate_r1cs_constraints();
+    _compute_vk_delta_g2_precomp->generate_r1cs_constraints();
 }
 
 template<typename ppT>
 void r1cs_gg_ppzksnark_verifier_process_vk_gadget<ppT>::generate_r1cs_witness()
 {
-    compute_vk_alpha_g1_precomp->generate_r1cs_witness();
+    _compute_vk_alpha_g1_precomp->generate_r1cs_witness();
 
-    compute_vk_beta_g2_precomp->generate_r1cs_witness();
-    compute_vk_delta_g2_precomp->generate_r1cs_witness();
+    _compute_vk_beta_g2_precomp->generate_r1cs_witness();
+    _compute_vk_delta_g2_precomp->generate_r1cs_witness();
 }
 
 template<typename ppT>
@@ -330,29 +336,29 @@ r1cs_gg_ppzksnark_online_verifier_gadget<ppT>::
         const libsnark::pb_variable<FieldT> &result_QAP_valid,
         const std::string &annotation_prefix)
     : libsnark::gadget<FieldT>(pb, annotation_prefix)
-    , pvk(pvk)
-    , input(input)
-    , elt_size(elt_size)
-    , proof(proof)
-    , result(result_QAP_valid)
-    , input_len(input.size())
+    , _pvk(pvk)
+    , _input(input)
+    , _elt_size(elt_size)
+    , _proof(proof)
+    , _result(result_QAP_valid)
+    , _input_len(input.size())
 {
     // 1. Accumulate input and store base in acc
     // See:
     // https://github.com/clearmatics/libsnark/blob/master/libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.tcc#L568-L571
-    acc.reset(
+    _acc.reset(
         new libsnark::G1_variable<ppT>(pb, FMT(annotation_prefix, " acc")));
     std::vector<libsnark::G1_variable<ppT>> IC_terms;
-    for (size_t i = 0; i < pvk.ABC_g1.size(); ++i) {
-        IC_terms.emplace_back(*(pvk.ABC_g1[i]));
+    for (size_t i = 0; i < _pvk._ABC_g1.size(); ++i) {
+        IC_terms.emplace_back(*(_pvk._ABC_g1[i]));
     }
-    accumulate_input.reset(new libsnark::G1_multiscalar_mul_gadget<ppT>(
+    _accumulate_input.reset(new libsnark::G1_multiscalar_mul_gadget<ppT>(
         pb,
-        *(pvk.encoded_ABC_base),
-        input,
-        elt_size,
+        *(_pvk._encoded_ABC_base),
+        _input,
+        _elt_size,
         IC_terms,
-        *acc,
+        *_acc,
         FMT(annotation_prefix, " accumulate_input")));
 
     // 2. Do the precomputations on the inputs of the pairings
@@ -360,47 +366,47 @@ r1cs_gg_ppzksnark_online_verifier_gadget<ppT>::
     // https://github.com/clearmatics/libsnark/blob/master/libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.tcc#L588-L591
     //
     // 2.1 Allocate the results of the precomputations
-    proof_g_A_precomp.reset(new G1_precomputation<ppT>());
-    proof_g_B_precomp.reset(new G2_precomputation<ppT>());
-    proof_g_C_precomp.reset(new G1_precomputation<ppT>());
-    acc_precomp.reset(new G1_precomputation<ppT>());
+    _proof_g_A_precomp.reset(new G1_precomputation<ppT>());
+    _proof_g_B_precomp.reset(new G2_precomputation<ppT>());
+    _proof_g_C_precomp.reset(new G1_precomputation<ppT>());
+    _acc_precomp.reset(new G1_precomputation<ppT>());
     // 2.2 Do the precomputations
-    compute_proof_g_A_precomp.reset(new G1_precompute_gadget<ppT>(
+    _compute_proof_g_A_precomp.reset(new G1_precompute_gadget<ppT>(
         pb,
-        *(proof.g_A),
-        *proof_g_A_precomp,
+        *(proof._g_A),
+        *_proof_g_A_precomp,
         FMT(annotation_prefix, " compute_proof_g_A_precomp")));
-    compute_proof_g_B_precomp.reset(new G2_precompute_gadget<ppT>(
+    _compute_proof_g_B_precomp.reset(new G2_precompute_gadget<ppT>(
         pb,
-        *(proof.g_B),
-        *proof_g_B_precomp,
+        *(proof._g_B),
+        *_proof_g_B_precomp,
         FMT(annotation_prefix, " compute_proof_g_B_precomp")));
-    compute_proof_g_C_precomp.reset(new G1_precompute_gadget<ppT>(
+    _compute_proof_g_C_precomp.reset(new G1_precompute_gadget<ppT>(
         pb,
-        *(proof.g_C),
-        *proof_g_C_precomp,
+        *(proof._g_C),
+        *_proof_g_C_precomp,
         FMT(annotation_prefix, " compute_proof_g_C_precomp")));
-    compute_acc_precomp.reset(new G1_precompute_gadget<ppT>(
+    _compute_acc_precomp.reset(new G1_precompute_gadget<ppT>(
         pb,
-        *acc,
-        *acc_precomp,
+        *_acc,
+        *_acc_precomp,
         FMT(annotation_prefix, " compute_acc_precomp")));
 
     // 3. Carry out the pairing checks to check QAP equation
-    check_QAP_valid.reset(new check_e_equals_eee_gadget<ppT>(
+    _check_QAP_valid.reset(new check_e_equals_eee_gadget<ppT>(
         pb,
         // LHS
-        *proof_g_A_precomp,
-        *proof_g_B_precomp,
+        *_proof_g_A_precomp,
+        *_proof_g_B_precomp,
         // RHS
-        *(pvk.vk_alpha_g1_precomp),
-        *(pvk.vk_beta_g2_precomp),
-        *(acc_precomp),
-        *(pvk.vk_generator_g2_precomp),
-        *(proof_g_C_precomp),
-        *(pvk.vk_delta_g2_precomp),
+        *(pvk._vk_alpha_g1_precomp),
+        *(pvk._vk_beta_g2_precomp),
+        *(_acc_precomp),
+        *(pvk._vk_generator_g2_precomp),
+        *(_proof_g_C_precomp),
+        *(pvk._vk_delta_g2_precomp),
         // Result of pairing check (allocated outside of this circuit)
-        result,
+        _result,
         FMT(annotation_prefix, " check_QAP_valid")));
 }
 
@@ -415,32 +421,32 @@ void r1cs_gg_ppzksnark_online_verifier_gadget<ppT>::generate_r1cs_constraints()
         libff::print_indent();
         printf(
             "* Number of bits as an input to verifier gadget: %zu\n",
-            input.size());
-        accumulate_input->generate_r1cs_constraints();
+            _input.size());
+        _accumulate_input->generate_r1cs_constraints();
     }
 
     PROFILE_CONSTRAINTS(this->pb, "rest of the verifier")
     {
-        compute_proof_g_A_precomp->generate_r1cs_constraints();
-        compute_proof_g_B_precomp->generate_r1cs_constraints();
-        compute_proof_g_C_precomp->generate_r1cs_constraints();
-        compute_acc_precomp->generate_r1cs_constraints();
+        _compute_proof_g_A_precomp->generate_r1cs_constraints();
+        _compute_proof_g_B_precomp->generate_r1cs_constraints();
+        _compute_proof_g_C_precomp->generate_r1cs_constraints();
+        _compute_acc_precomp->generate_r1cs_constraints();
 
-        check_QAP_valid->generate_r1cs_constraints();
+        _check_QAP_valid->generate_r1cs_constraints();
     }
 }
 
 template<typename ppT>
 void r1cs_gg_ppzksnark_online_verifier_gadget<ppT>::generate_r1cs_witness()
 {
-    accumulate_input->generate_r1cs_witness();
+    _accumulate_input->generate_r1cs_witness();
 
-    compute_proof_g_A_precomp->generate_r1cs_witness();
-    compute_proof_g_B_precomp->generate_r1cs_witness();
-    compute_proof_g_C_precomp->generate_r1cs_witness();
-    compute_acc_precomp->generate_r1cs_witness();
+    _compute_proof_g_A_precomp->generate_r1cs_witness();
+    _compute_proof_g_B_precomp->generate_r1cs_witness();
+    _compute_proof_g_C_precomp->generate_r1cs_witness();
+    _compute_acc_precomp->generate_r1cs_witness();
 
-    check_QAP_valid->generate_r1cs_witness();
+    _check_QAP_valid->generate_r1cs_witness();
 }
 
 template<typename ppT>
@@ -454,14 +460,14 @@ r1cs_gg_ppzksnark_verifier_gadget<ppT>::r1cs_gg_ppzksnark_verifier_gadget(
     const std::string &annotation_prefix)
     : libsnark::gadget<FieldT>(pb, annotation_prefix)
 {
-    pvk.reset(
+    _pvk.reset(
         new r1cs_gg_ppzksnark_preprocessed_r1cs_gg_ppzksnark_verification_key_variable<
             ppT>());
-    compute_pvk.reset(new r1cs_gg_ppzksnark_verifier_process_vk_gadget<ppT>(
-        pb, vk, *pvk, FMT(annotation_prefix, " compute_pvk")));
-    online_verifier.reset(new r1cs_gg_ppzksnark_online_verifier_gadget<ppT>(
+    _compute_pvk.reset(new r1cs_gg_ppzksnark_verifier_process_vk_gadget<ppT>(
+        pb, vk, *_pvk, FMT(annotation_prefix, " compute_pvk")));
+    _online_verifier.reset(new r1cs_gg_ppzksnark_online_verifier_gadget<ppT>(
         pb,
-        *pvk,
+        *_pvk,
         input,
         elt_size,
         proof,
@@ -477,20 +483,20 @@ void r1cs_gg_ppzksnark_verifier_gadget<ppT>::generate_r1cs_constraints()
 
     PROFILE_CONSTRAINTS(this->pb, "precompute pvk")
     {
-        compute_pvk->generate_r1cs_constraints();
+        _compute_pvk->generate_r1cs_constraints();
     }
 
     PROFILE_CONSTRAINTS(this->pb, "online verifier")
     {
-        online_verifier->generate_r1cs_constraints();
+        _online_verifier->generate_r1cs_constraints();
     }
 }
 
 template<typename ppT>
 void r1cs_gg_ppzksnark_verifier_gadget<ppT>::generate_r1cs_witness()
 {
-    compute_pvk->generate_r1cs_witness();
-    online_verifier->generate_r1cs_witness();
+    _compute_pvk->generate_r1cs_witness();
+    _online_verifier->generate_r1cs_witness();
 }
 
 } // namespace libzecale

--- a/libzecale/circuits/groth16_verifier/r1cs_gg_ppzksnark_verifier_gadget.tcc
+++ b/libzecale/circuits/groth16_verifier/r1cs_gg_ppzksnark_verifier_gadget.tcc
@@ -37,14 +37,14 @@ r1cs_gg_ppzksnark_proof_variable<ppT>::r1cs_gg_ppzksnark_proof_variable(
     _all_G1_checkers.resize(_all_G1_vars.size());
 
     for (size_t i = 0; i < _all_G1_vars.size(); ++i) {
-        _all_G1_checkers[i].reset(new libsnark::G1_checker_gadget<ppT>(
+        _all_G1_checkers[i].reset(new G1_checker<ppT>(
             pb,
             *_all_G1_vars[i],
             FMT(annotation_prefix, " all_G1_checkers_%zu", i)));
     }
 
-    _G2_checker.reset(new libsnark::G2_checker_gadget<ppT>(
-        pb, *_g_B, FMT(annotation_prefix, " G2_checker")));
+    _G2_checker.reset(
+        new G2_checker<ppT>(pb, *_g_B, FMT(annotation_prefix, " G2_checker")));
 
     assert(_all_G1_vars.size() == num_G1);
     assert(_all_G2_vars.size() == num_G2);

--- a/libzecale/circuits/pairing/bw6_761_pairing_params.hpp
+++ b/libzecale/circuits/pairing/bw6_761_pairing_params.hpp
@@ -6,6 +6,7 @@
 #define __ZECALE_CIRCUITS_PAIRING_BW6_761_PAIRING_PARAMS_HPP__
 
 #include "libzecale/circuits/fields/fp12_2over3over2_gadgets.hpp"
+#include "libzecale/circuits/pairing/bls12_377_membership_check_gadgets.hpp"
 #include "libzecale/circuits/pairing/bls12_377_pairing.hpp"
 #include "libzecale/circuits/pairing/pairing_params.hpp"
 
@@ -53,6 +54,10 @@ public:
 
     typedef libff::bls12_377_pp other_curve_type;
 
+    typedef bls12_377_G1_membership_check_gadget<libff::bw6_761_pp>
+        G1_checker_type;
+    typedef bls12_377_G2_membership_check_gadget<libff::bw6_761_pp>
+        G2_checker_type;
     typedef bls12_377_G1_precomputation<libff::bw6_761_pp>
         G1_precomputation_type;
     typedef bls12_377_G1_precompute_gadget<libff::bw6_761_pp>

--- a/libzecale/circuits/pairing/mnt_pairing_params.hpp
+++ b/libzecale/circuits/pairing/mnt_pairing_params.hpp
@@ -41,6 +41,9 @@ public:
 
     typedef libff::mnt6_pp other_curve_type;
 
+    typedef libsnark::G1_checker_gadget<libff::mnt4_pp> G1_checker_type;
+    typedef libsnark::G2_checker_gadget<libff::mnt4_pp> G2_checker_type;
+
     typedef libsnark::G1_precomputation<libff::mnt4_pp> G1_precomputation_type;
     typedef libsnark::precompute_G1_gadget<libff::mnt4_pp>
         G1_precompute_gadget_type;
@@ -84,6 +87,9 @@ public:
     typedef libsnark::Fp4_sqr_gadget<FqkT> Fqk_sqr_gadget_type;
 
     typedef libff::mnt4_pp other_curve_type;
+
+    typedef libsnark::G1_checker_gadget<libff::mnt6_pp> G1_checker_type;
+    typedef libsnark::G2_checker_gadget<libff::mnt6_pp> G2_checker_type;
 
     typedef libsnark::G1_precomputation<libff::mnt6_pp> G1_precomputation_type;
     typedef libsnark::precompute_G1_gadget<libff::mnt6_pp>

--- a/libzecale/circuits/pairing/pairing_params.hpp
+++ b/libzecale/circuits/pairing/pairing_params.hpp
@@ -60,6 +60,8 @@ namespace libzecale
  *       typedef my_Fqk_special_mul_gadget_type Fqk_special_mul_gadget_type;
  *       typedef my_Fqk_sqr_gadget_type Fqk_sqr_gadget_type;
  *       typedef my_other_curve_type other_curve_type;
+ *       typedef my_G1_checker_gadget_type G1_checker_type;
+ *       typedef my_G2_checker_gadget_type G2_checker_type;
  *       typedef my_G1_precompute_variable_type G1_precompute_variable_type;
  *       typedef my_G1_precompute_gadget_type G1_precompute_gadget_type;
  *       typedef my_G2_precompute_variable_type G2_precompute_variable_type;
@@ -110,6 +112,11 @@ using other_curve = typename pairing_selector<ppT>::other_curve_type;
 
 // Note, these names conflict with concrete classes in libsnark, which are
 // specialized for MNT. Care must be taken with namespaces.
+
+template<typename ppT>
+using G1_checker = typename pairing_selector<ppT>::G1_checker_type;
+template<typename ppT>
+using G2_checker = typename pairing_selector<ppT>::G2_checker_type;
 
 template<typename ppT>
 using G1_precomputation =

--- a/libzecale/circuits/verification_key_hash_gadget.tcc
+++ b/libzecale/circuits/verification_key_hash_gadget.tcc
@@ -19,7 +19,9 @@ verification_key_hash_gadget<wppT, nverifierT, hashT>::
         const std::string &annotation_prefix)
     : libsnark::gadget<FieldT>(pb, annotation_prefix)
     , _vk_block(
-          pb, {verification_key.all_bits}, FMT(annotation_prefix, " _vk_block"))
+          pb,
+          {verification_key._all_bits},
+          FMT(annotation_prefix, " _vk_block"))
     , _vk_digest(
           pb, hashT::get_digest_len(), FMT(annotation_prefix, " _vk_digest"))
     , _hash_gadget(


### PR DESCRIPTION
- [x] Parameterize the group checker gadgets
- [x] (member naming changes required to enable the above)
- [x] Use new membership check gadgets for ppT == bw6_761_pp

(Depend son #57)

Note, in order to avoid conflicts between type names and clas member names, this PR includes a trivial renaming of members (addimg the `_` prefix).  This happens in it's own commit to make it easier to see the actual code change.