### PR TITLE
Use mimc-based hash function for nested verification key digest

### DIFF
--- a/client/zecale/cli/zecale_nested_verification_key_hash.py
+++ b/client/zecale/cli/zecale_nested_verification_key_hash.py
@@ -26,11 +26,14 @@ def nested_verification_key_hash(
     aggregator_client = cmd_ctx.get_aggregator_client()
     vk_hash_hex = aggregator_client.get_nested_verification_key_hash(snark, vk)
 
-    # Decode the key into evm words and extract the lowest order one. Assert
-    # that the higher order ints are all zero.
+    # Use the lowest order uint256_t for the client application. (The wrapping
+    # zk-snark still uses the full width hash, which is returned by the
+    # aggregation server as a primary input when a batch is created).
     vk_hash_evm = list(hex_to_uint256_list(vk_hash_hex))
     vk_hash = vk_hash_evm[-1]
-    for i in vk_hash_evm[:-1]:
-        assert i == 0, "expected higher orders words to be 0"
+
+    # TODO: pass the full-width vk_hash to to the application (requires the
+    # dispatch interface to be updated), or show that using the LO word
+    # is still collision resistant.
 
     print(vk_hash.to_bytes(32, byteorder='big').hex())

--- a/contracts/ZecaleDispatcher.sol
+++ b/contracts/ZecaleDispatcher.sol
@@ -109,7 +109,7 @@ contract ZecaleDispatcher
         // word of the first nested input. (See notes above about scalar
         // sizes).
 
-        // Cache the nested VK (LO word) and
+        // Cache the nested VK (LO word) to pass to the application.
         uint256 nested_vk_hash = inputs[1];
         uint256 inputs_per_nested_tx = _inputs_per_nested_tx;
 

--- a/libzecale/circuits/aggregator_circuit.hpp
+++ b/libzecale/circuits/aggregator_circuit.hpp
@@ -37,19 +37,14 @@ namespace libzecale
 ///   M = num_inputs_per_nested_proof,
 ///   input[i,j] = j-th input to i-th proof,
 ///   result[i] = result of i-th proof verification)
-template<
-    typename wppT,
-    typename wsnarkT,
-    typename nverifierT,
-    typename hashT,
-    size_t NumProofs>
+template<typename wppT, typename wsnarkT, typename nverifierT, size_t NumProofs>
 class aggregator_circuit
 {
 private:
     using npp = other_curve<wppT>;
     using nsnark = typename nverifierT::snark;
     using verification_key_variable_gadget =
-        typename nverifierT::verification_key_variable_gadget;
+        typename nverifierT::verification_key_scalar_variable_gadget;
     using proof_variable_gadget = typename nverifierT::proof_variable_gadget;
 
     const size_t _num_inputs_per_nested_proof;
@@ -87,7 +82,7 @@ private:
         _nested_proofs;
 
     /// Gadget to check the hash of the nested verification key.
-    std::shared_ptr<verification_key_hash_gadget<wppT, nverifierT, hashT>>
+    std::shared_ptr<verification_key_scalar_hash_gadget<wppT, nverifierT>>
         _nested_vk_hash_gadget;
 
     /// Gadget to aggregate proofs.

--- a/libzecale/circuits/aggregator_gadget.hpp
+++ b/libzecale/circuits/aggregator_gadget.hpp
@@ -38,7 +38,7 @@ private:
     using verifier_gadget = typename nverifierT::verifier_gadget;
     using proof_variable_gadget = typename nverifierT::proof_variable_gadget;
     using verification_key_variable_gadget =
-        typename nverifierT::verification_key_variable_gadget;
+        typename nverifierT::verification_key_scalar_variable_gadget;
     using input_packing_gadget = libsnark::multipacking_gadget<libff::Fr<wppT>>;
 
     const size_t num_inputs_per_nested_proof;

--- a/libzecale/circuits/aggregator_gadget.tcc
+++ b/libzecale/circuits/aggregator_gadget.tcc
@@ -21,7 +21,7 @@ aggregator_gadget<wppT, nverifierT, NumProofs>::aggregator_gadget(
         &proof_results,
     const std::string &annotation_prefix)
     : libsnark::gadget<libff::Fr<wppT>>(pb, annotation_prefix)
-    , num_inputs_per_nested_proof(vk._input_size)
+    , num_inputs_per_nested_proof(vk._num_primary_inputs)
     , nested_primary_inputs(inputs)
 {
     // Assert that a single input of a nested proof (element of

--- a/libzecale/circuits/groth16_verifier/groth16_verifier_parameters.hpp
+++ b/libzecale/circuits/groth16_verifier/groth16_verifier_parameters.hpp
@@ -22,6 +22,8 @@ public:
     using proof_variable_gadget = r1cs_gg_ppzksnark_proof_variable<ppT>;
     using verification_key_variable_gadget =
         r1cs_gg_ppzksnark_verification_key_variable<ppT>;
+    using verification_key_scalar_variable_gadget =
+        r1cs_gg_ppzksnark_verification_key_scalar_variable<ppT>;
 };
 
 } // namespace libzecale

--- a/libzecale/circuits/groth16_verifier/r1cs_gg_ppzksnark_verifier_gadget.hpp
+++ b/libzecale/circuits/groth16_verifier/r1cs_gg_ppzksnark_verifier_gadget.hpp
@@ -65,24 +65,14 @@ public:
 
     libsnark::pb_variable_array<FieldT> _all_bits;
     libsnark::pb_linear_combination_array<FieldT> _all_vars;
-    size_t _input_size;
+    const size_t _num_primary_inputs;
 
     std::shared_ptr<libsnark::multipacking_gadget<FieldT>> _packer;
 
-    // Unfortunately, g++ 4.9 and g++ 5.0 have a bug related to
-    // incorrect inlining of small functions:
-    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65307, which
-    // produces wrong assembly even at -O1. The test case at the bug
-    // report is directly derived from this code here. As a temporary
-    // work-around we mark the key functions noinline to hint compiler
-    // that inlining should not be performed.
-
-    // TODO: remove later, when g++ developers fix the bug.
-
-    __attribute__((noinline)) r1cs_gg_ppzksnark_verification_key_variable(
+    r1cs_gg_ppzksnark_verification_key_variable(
         libsnark::protoboard<FieldT> &pb,
         const libsnark::pb_variable_array<FieldT> &all_bits,
-        const size_t input_size,
+        const size_t num_primary_inputs,
         const std::string &annotation_prefix);
     void generate_r1cs_constraints(const bool enforce_bitness);
     void generate_r1cs_witness(

--- a/libzecale/circuits/groth16_verifier/r1cs_gg_ppzksnark_verifier_gadget.hpp
+++ b/libzecale/circuits/groth16_verifier/r1cs_gg_ppzksnark_verifier_gadget.hpp
@@ -87,6 +87,40 @@ public:
             &r1cs_vk);
 };
 
+/// A version of r1cs_gg_ppzksnark_verification_key_variable without variables
+/// for the bits. In the case where an algebraic hash of the verification key
+/// is used, this type saves many unnecessary variables.
+template<typename ppT>
+class r1cs_gg_ppzksnark_verification_key_scalar_variable
+    : public libsnark::gadget<libff::Fr<ppT>>
+{
+public:
+    typedef libff::Fr<ppT> FieldT;
+
+    libsnark::G1_variable<ppT> _alpha_g1;
+    libsnark::G2_variable<ppT> _beta_g2;
+    libsnark::G2_variable<ppT> _delta_g2;
+    std::shared_ptr<libsnark::G1_variable<ppT>> _encoded_ABC_base;
+    std::vector<std::shared_ptr<libsnark::G1_variable<ppT>>> _ABC_g1;
+
+    libsnark::pb_linear_combination_array<FieldT> _all_vars;
+    const size_t _num_primary_inputs;
+
+    r1cs_gg_ppzksnark_verification_key_scalar_variable(
+        libsnark::protoboard<FieldT> &pb,
+        const size_t num_primary_inputs,
+        const std::string &annotation_prefix);
+    void generate_r1cs_constraints();
+    void generate_r1cs_witness(
+        const libsnark::r1cs_gg_ppzksnark_verification_key<other_curve<ppT>>
+            &vk);
+
+    const libsnark::pb_linear_combination_array<FieldT> &get_all_vars() const;
+    static std::vector<FieldT> get_verification_key_scalars(
+        const libsnark::r1cs_gg_ppzksnark_verification_key<other_curve<ppT>>
+            &r1cs_vk);
+};
+
 template<typename ppT>
 class r1cs_gg_ppzksnark_preprocessed_r1cs_gg_ppzksnark_verification_key_variable
 {

--- a/libzecale/circuits/groth16_verifier/r1cs_gg_ppzksnark_verifier_gadget.hpp
+++ b/libzecale/circuits/groth16_verifier/r1cs_gg_ppzksnark_verifier_gadget.hpp
@@ -156,13 +156,13 @@ public:
     std::shared_ptr<G2_precompute_gadget<ppT>> _compute_vk_beta_g2_precomp;
     std::shared_ptr<G2_precompute_gadget<ppT>> _compute_vk_delta_g2_precomp;
 
-    r1cs_gg_ppzksnark_verification_key_variable<ppT> _vk;
+    r1cs_gg_ppzksnark_verification_key_scalar_variable<ppT> _vk;
     r1cs_gg_ppzksnark_preprocessed_r1cs_gg_ppzksnark_verification_key_variable<
         ppT> &_pvk;
 
     r1cs_gg_ppzksnark_verifier_process_vk_gadget(
         libsnark::protoboard<FieldT> &pb,
-        const r1cs_gg_ppzksnark_verification_key_variable<ppT> &vk,
+        const r1cs_gg_ppzksnark_verification_key_scalar_variable<ppT> &vk,
         r1cs_gg_ppzksnark_preprocessed_r1cs_gg_ppzksnark_verification_key_variable<
             ppT> &pvk,
         const std::string &annotation_prefix);
@@ -234,7 +234,7 @@ public:
 
     r1cs_gg_ppzksnark_verifier_gadget(
         libsnark::protoboard<FieldT> &pb,
-        const r1cs_gg_ppzksnark_verification_key_variable<ppT> &vk,
+        const r1cs_gg_ppzksnark_verification_key_scalar_variable<ppT> &vk,
         const libsnark::pb_variable_array<FieldT> &input,
         const size_t elt_size,
         const r1cs_gg_ppzksnark_proof_variable<ppT> &proof,

--- a/libzecale/circuits/groth16_verifier/r1cs_gg_ppzksnark_verifier_gadget.tcc
+++ b/libzecale/circuits/groth16_verifier/r1cs_gg_ppzksnark_verifier_gadget.tcc
@@ -371,7 +371,7 @@ template<typename ppT>
 r1cs_gg_ppzksnark_verifier_process_vk_gadget<ppT>::
     r1cs_gg_ppzksnark_verifier_process_vk_gadget(
         libsnark::protoboard<FieldT> &pb,
-        const r1cs_gg_ppzksnark_verification_key_variable<ppT> &vk,
+        const r1cs_gg_ppzksnark_verification_key_scalar_variable<ppT> &vk,
         r1cs_gg_ppzksnark_preprocessed_r1cs_gg_ppzksnark_verification_key_variable<
             ppT> &pvk,
         const std::string &annotation_prefix)
@@ -388,7 +388,7 @@ r1cs_gg_ppzksnark_verifier_process_vk_gadget<ppT>::
 
     _compute_vk_alpha_g1_precomp.reset(new G1_precompute_gadget<ppT>(
         pb,
-        *vk._alpha_g1,
+        vk._alpha_g1,
         *pvk._vk_alpha_g1_precomp,
         FMT(annotation_prefix, " compute_vk_alpha_g1_precomp")));
 
@@ -398,12 +398,12 @@ r1cs_gg_ppzksnark_verifier_process_vk_gadget<ppT>::
         FMT(annotation_prefix, " vk_generator_g2_precomp")));
     _compute_vk_beta_g2_precomp.reset(new G2_precompute_gadget<ppT>(
         pb,
-        *vk._beta_g2,
+        vk._beta_g2,
         *pvk._vk_beta_g2_precomp,
         FMT(annotation_prefix, " compute_vk_beta_g2_precomp")));
     _compute_vk_delta_g2_precomp.reset(new G2_precompute_gadget<ppT>(
         pb,
-        *vk._delta_g2,
+        vk._delta_g2,
         *pvk._vk_delta_g2_precomp,
         FMT(annotation_prefix, " compute_vk_delta_g2_precomp")));
 }
@@ -555,7 +555,7 @@ void r1cs_gg_ppzksnark_online_verifier_gadget<ppT>::generate_r1cs_witness()
 template<typename ppT>
 r1cs_gg_ppzksnark_verifier_gadget<ppT>::r1cs_gg_ppzksnark_verifier_gadget(
     libsnark::protoboard<FieldT> &pb,
-    const r1cs_gg_ppzksnark_verification_key_variable<ppT> &vk,
+    const r1cs_gg_ppzksnark_verification_key_scalar_variable<ppT> &vk,
     const libsnark::pb_variable_array<FieldT> &input,
     const size_t elt_size,
     const r1cs_gg_ppzksnark_proof_variable<ppT> &proof,

--- a/libzecale/circuits/pairing/bw6_761_pairing_params.hpp
+++ b/libzecale/circuits/pairing/bw6_761_pairing_params.hpp
@@ -14,6 +14,7 @@
 #include <libff/algebra/curves/bw6_761/bw6_761_pp.hpp>
 #include <libsnark/gadgetlib1/gadgets/fields/fp2_gadgets.hpp>
 #include <libsnark/gadgetlib1/gadgets/pairing/pairing_params.hpp>
+#include <libzeth/circuits/mimc/mimc_mp.hpp>
 
 namespace libzecale
 {
@@ -80,6 +81,13 @@ public:
 
     static const constexpr libff::bigint<libff::bw6_761_Fr::num_limbs>
         &pairing_loop_count = libff::bls12_377_ate_loop_count;
+
+    // Constants e=31, r=77 computed via scripts/mimc_constraints.sage in
+    // http://github.com/clearmatics/zeth.
+    typedef libzeth::MiMC_mp_gadget<
+        libff::bw6_761_Fr,
+        libzeth::MiMC_permutation_gadget<libff::bw6_761_Fr, 31, 77>>
+        compression_function_gadget_type;
 };
 
 template<>

--- a/libzecale/circuits/pairing/mnt_pairing_params.hpp
+++ b/libzecale/circuits/pairing/mnt_pairing_params.hpp
@@ -16,6 +16,7 @@
 #include <libsnark/gadgetlib1/gadgets/fields/fp6_gadgets.hpp>
 #include <libsnark/gadgetlib1/gadgets/pairing/weierstrass_final_exponentiation.hpp>
 #include <libsnark/gadgetlib1/gadgets/pairing/weierstrass_precomputation.hpp>
+#include <libzeth/circuits/mimc/mimc_mp.hpp>
 
 namespace libzecale
 {
@@ -64,6 +65,13 @@ public:
 
     static const constexpr libff::bigint<libff::mnt6_Fr::num_limbs>
         &pairing_loop_count = libff::mnt6_ate_loop_count;
+
+    // Constants e=31, r=61 computed via scripts/mimc_constraints.sage in
+    // http://github.com/clearmatics/zeth.
+    typedef libzeth::MiMC_mp_gadget<
+        libff::mnt4_Fr,
+        libzeth::MiMC_permutation_gadget<libff::mnt4_Fr, 31, 61>>
+        compression_function_gadget_type;
 };
 
 // Specialization for MNT6.
@@ -111,6 +119,13 @@ public:
 
     static const constexpr libff::bigint<libff::mnt4_Fr::num_limbs>
         &pairing_loop_count = libff::mnt4_ate_loop_count;
+
+    // Constants e=31, r=61 computed via scripts/mimc_constraints.sage in
+    // http://github.com/clearmatics/zeth.
+    typedef libzeth::MiMC_mp_gadget<
+        libff::mnt6_Fr,
+        libzeth::MiMC_permutation_gadget<libff::mnt6_Fr, 31, 61>>
+        compression_function_gadget_type;
 };
 
 } // namespace libzecale

--- a/libzecale/circuits/pairing/pairing_params.hpp
+++ b/libzecale/circuits/pairing/pairing_params.hpp
@@ -144,6 +144,10 @@ using e_times_e_times_e_over_e_miller_loop_gadget = typename pairing_selector<
 template<typename ppT>
 using final_exp_gadget = typename pairing_selector<ppT>::final_exp_gadget_type;
 
+template<typename ppT>
+using compression_function_gadget =
+    typename pairing_selector<ppT>::compression_function_gadget_type;
+
 } // namespace libzecale
 
 #endif // __ZECALE_CIRCUITS_PAIRING_PAIRING_PARAMS_HPP__

--- a/libzecale/circuits/pghr13_verifier/pghr13_verifier_parameters.hpp
+++ b/libzecale/circuits/pghr13_verifier/pghr13_verifier_parameters.hpp
@@ -5,6 +5,8 @@
 #ifndef __ZECALE_CIRCUITS_PGHR13_VERIFIER_PGHR13_VERIFIER_PARAMETERS_HPP__
 #define __ZECALE_CIRCUITS_PGHR13_VERIFIER_PGHR13_VERIFIER_PARAMETERS_HPP__
 
+#include "libzecale/circuits/pghr13_verifier/r1cs_ppzksnark_verification_key_scalar_variable.hpp"
+
 #include <libsnark/gadgetlib1/gadgets/verifiers/r1cs_ppzksnark_verifier_gadget.hpp>
 #include <libzeth/snarks/pghr13/pghr13_snark.hpp>
 
@@ -20,6 +22,8 @@ public:
     using proof_variable_gadget = libsnark::r1cs_ppzksnark_proof_variable<ppT>;
     using verification_key_variable_gadget =
         libsnark::r1cs_ppzksnark_verification_key_variable<ppT>;
+    using verification_key_scalar_variable_gadget =
+        r1cs_ppzksnark_verification_key_scalar_variable<ppT>;
 };
 
 } // namespace libzecale

--- a/libzecale/circuits/pghr13_verifier/r1cs_ppzksnark_verification_key_scalar_variable.hpp
+++ b/libzecale/circuits/pghr13_verifier/r1cs_ppzksnark_verification_key_scalar_variable.hpp
@@ -1,0 +1,50 @@
+// Copyright (c) 2015-2021 Clearmatics Technologies Ltd
+//
+// SPDX-License-Identifier: LGPL-3.0+
+
+#ifndef __ZECALE_CIRCUITS_PGHR13_VERIFIER_R1CS_PPZKSNARK_VERIFICATION_KEY_SCALAR_VARIABLE_HPP__
+#define __ZECALE_CIRCUITS_PGHR13_VERIFIER_R1CS_PPZKSNARK_VERIFICATION_KEY_SCALAR_VARIABLE_HPP__
+
+#include <libsnark/gadgetlib1/gadgets/verifiers/r1cs_ppzksnark_verifier_gadget.hpp>
+
+namespace libzecale
+{
+
+/// Version of libsnark::r1cs_ppzksnark_verification_key_variable that exposes
+/// the scalar variables (equivalent of
+/// r1cs_gg_ppzksnark_verification_key_scalar_variable). We are forced to
+/// inherit from libsnark::r1cs_ppzksnark_verification_key_variable in order
+/// that this object can be passed to the
+/// libsnark::r1cs_ppzksnark_verifier_gadget, hence this version is not optimal
+/// (the bit variables are all still allocated). An optimal version would
+/// require larger changes in libsnark.
+template<typename ppT>
+class r1cs_ppzksnark_verification_key_scalar_variable
+    : public libsnark::r1cs_ppzksnark_verification_key_variable<ppT>
+{
+public:
+    using FieldT = libff::Fr<ppT>;
+
+    r1cs_ppzksnark_verification_key_scalar_variable(
+        libsnark::protoboard<FieldT> &pb,
+        const size_t input_size,
+        const std::string &annotation_prefix);
+
+    void generate_r1cs_constraints();
+    const libsnark::pb_linear_combination_array<FieldT> &get_all_vars() const;
+    static std::vector<FieldT> get_verification_key_scalars(
+        const libsnark::r1cs_ppzksnark_verification_key<other_curve<ppT>>
+            &r1cs_vk);
+
+private:
+    static libsnark::pb_variable_array<FieldT> allocate_all_bits(
+        libsnark::protoboard<FieldT> &pb,
+        const size_t input_size,
+        const std::string &annotation_prefix);
+};
+
+} // namespace libzecale
+
+#include "libzecale/circuits/pghr13_verifier/r1cs_ppzksnark_verification_key_scalar_variable.tcc"
+
+#endif // __ZECALE_CIRCUITS_PGHR13_VERIFIER_R1CS_PPZKSNARK_VERIFICATION_KEY_SCALAR_VARIABLE_HPP__

--- a/libzecale/circuits/pghr13_verifier/r1cs_ppzksnark_verification_key_scalar_variable.tcc
+++ b/libzecale/circuits/pghr13_verifier/r1cs_ppzksnark_verification_key_scalar_variable.tcc
@@ -1,0 +1,93 @@
+// Copyright (c) 2015-2021 Clearmatics Technologies Ltd
+//
+// SPDX-License-Identifier: LGPL-3.0+
+
+#ifndef __ZECALE_CIRCUITS_PGHR13_VERIFIER_R1CS_PPZKSNARK_VERIFICATION_KEY_SCALAR_VARIABLE_TCC__
+#define __ZECALE_CIRCUITS_PGHR13_VERIFIER_R1CS_PPZKSNARK_VERIFICATION_KEY_SCALAR_VARIABLE_TCC__
+
+#include "libzecale/circuits/pghr13_verifier/r1cs_ppzksnark_verification_key_scalar_variable.hpp"
+
+namespace libzecale
+{
+
+template<typename ppT>
+r1cs_ppzksnark_verification_key_scalar_variable<ppT>::
+    r1cs_ppzksnark_verification_key_scalar_variable(
+        libsnark::protoboard<libff::Fr<ppT>> &pb,
+        const size_t input_size,
+        const std::string &annotation_prefix)
+    : libsnark::r1cs_ppzksnark_verification_key_variable<ppT>(
+          pb,
+          allocate_all_bits(pb, input_size, annotation_prefix),
+          input_size,
+          annotation_prefix)
+{
+}
+
+template<typename ppT>
+void r1cs_ppzksnark_verification_key_scalar_variable<
+    ppT>::generate_r1cs_constraints()
+{
+    libsnark::r1cs_ppzksnark_verification_key_variable<
+        ppT>::generate_r1cs_constraints(false);
+}
+
+template<typename ppT>
+const libsnark::pb_linear_combination_array<libff::Fr<ppT>>
+    &r1cs_ppzksnark_verification_key_scalar_variable<ppT>::get_all_vars() const
+{
+    return libsnark::r1cs_ppzksnark_verification_key_variable<ppT>::all_vars;
+}
+
+template<typename ppT>
+std::vector<libff::Fr<ppT>> r1cs_ppzksnark_verification_key_scalar_variable<
+    ppT>::
+    get_verification_key_scalars(
+        const libsnark::r1cs_ppzksnark_verification_key<other_curve<ppT>>
+            &r1cs_vk)
+{
+    const size_t input_size_in_elts =
+        r1cs_vk.encoded_IC_query.rest.indices
+            .size(); // this might be approximate for bound verification
+    // keys, however they are not supported by
+    // r1cs_ppzksnark_verification_key_variable
+    const size_t vk_size_in_bits =
+        libsnark::r1cs_ppzksnark_verification_key_variable<ppT>::size_in_bits(
+            input_size_in_elts);
+
+    libsnark::protoboard<FieldT> pb;
+    libsnark::pb_variable_array<FieldT> vk_bits;
+    vk_bits.allocate(pb, vk_size_in_bits, "vk_bits");
+    r1cs_ppzksnark_verification_key_scalar_variable<ppT> vk(
+        pb, vk_bits, input_size_in_elts, "translation_step_vk");
+    vk.generate_r1cs_witness(r1cs_vk);
+
+    const size_t num_scalars = vk.all_vars.size();
+    std::vector<FieldT> scalars;
+    scalars.reserve(num_scalars);
+    for (size_t i = 0; i < num_scalars; ++i) {
+        scalars.push_back(pb.lc_val(vk.all_vars[i]));
+    }
+
+    return scalars;
+}
+
+template<typename ppT>
+libsnark::pb_variable_array<libff::Fr<ppT>>
+r1cs_ppzksnark_verification_key_scalar_variable<ppT>::allocate_all_bits(
+    libsnark::protoboard<libff::Fr<ppT>> &pb,
+    const size_t input_size,
+    const std::string &annotation_prefix)
+{
+    libsnark::pb_variable_array<FieldT> arr;
+    arr.allocate(
+        pb,
+        libsnark::r1cs_ppzksnark_verification_key_variable<ppT>::size_in_bits(
+            input_size),
+        FMT(annotation_prefix, " vk_bits"));
+    return arr;
+}
+
+} // namespace libzecale
+
+#endif // __ZECALE_CIRCUITS_PGHR13_VERIFIER_R1CS_PPZKSNARK_VERIFICATION_KEY_SCALAR_VARIABLE_TCC__

--- a/libzecale/circuits/verification_key_hash_gadget.hpp
+++ b/libzecale/circuits/verification_key_hash_gadget.hpp
@@ -7,9 +7,43 @@
 
 #include <libsnark/gadgetlib1/gadgets/basic_gadgets.hpp>
 #include <libsnark/gadgetlib1/gadgets/hashes/hash_io.hpp>
+#include <libzeth/circuits/mimc/mimc_input_hasher.hpp>
 
 namespace libzecale
 {
+
+/// Gadget to produce the hash of a verification key for nested proofs. Relies
+/// on a hash gadget `hashT` which operates directly on arrays of scalars,
+/// producing digests which are also scalars.
+template<typename wppT, typename nverifierT>
+class verification_key_scalar_hash_gadget
+    : public libsnark::gadget<libff::Fr<wppT>>
+{
+public:
+    using FieldT = libff::Fr<wppT>;
+    using compFnT = compression_function_gadget<wppT>;
+    using scalarHasherT = libzeth::mimc_input_hasher<FieldT, compFnT>;
+
+    using nsnark = typename nverifierT::snark;
+    using verification_key_variable =
+        typename nverifierT::verification_key_scalar_variable_gadget;
+
+    /// Gadget to hash vk bits.
+    scalarHasherT _hash_gadget;
+
+    verification_key_scalar_hash_gadget(
+        libsnark::protoboard<FieldT> &pb,
+        verification_key_variable &verifcation_key,
+        libsnark::pb_variable<FieldT> &verification_key_hash,
+        const std::string &annotation);
+    void generate_r1cs_constraints();
+    void generate_r1cs_witness();
+
+    // TODO: should not require the second parameter, but there is no generic
+    // method to extract the number of inputs from the verification key.
+    static FieldT compute_hash(
+        const typename nsnark::verification_key &vk, size_t num_inputs);
+};
 
 /// Gadget to produce the hash of a verification key for nested proofs. As with
 /// generic hash gadgets, the boolean-ness of the input bits is not checked.

--- a/libzecale/circuits/verification_key_hash_gadget.tcc
+++ b/libzecale/circuits/verification_key_hash_gadget.tcc
@@ -10,6 +10,60 @@
 namespace libzecale
 {
 
+// verification_key_scalar_hash_gadget
+
+template<typename wppT, typename nverifierT>
+verification_key_scalar_hash_gadget<wppT, nverifierT>::
+    verification_key_scalar_hash_gadget(
+        libsnark::protoboard<FieldT> &pb,
+        verification_key_variable &verification_key,
+        libsnark::pb_variable<FieldT> &verification_key_hash,
+        const std::string &annotation_prefix)
+    : libsnark::gadget<FieldT>(pb, annotation_prefix)
+    , _hash_gadget(
+          pb,
+          verification_key.get_all_vars(),
+          verification_key_hash,
+          FMT(annotation_prefix, " _hash_gadget"))
+{
+}
+
+template<typename wppT, typename nverifierT>
+void verification_key_scalar_hash_gadget<wppT, nverifierT>::
+    generate_r1cs_constraints()
+{
+    _hash_gadget.generate_r1cs_constraints();
+}
+
+template<typename wppT, typename nverifierT>
+void verification_key_scalar_hash_gadget<wppT, nverifierT>::
+    generate_r1cs_witness()
+{
+    _hash_gadget.generate_r1cs_witness();
+}
+
+template<typename wppT, typename nverifierT>
+libff::Fr<wppT> verification_key_scalar_hash_gadget<wppT, nverifierT>::
+    compute_hash(const typename nsnark::verification_key &vk, size_t num_inputs)
+{
+    libsnark::protoboard<FieldT> pb;
+    libsnark::pb_variable<libff::Fr<wppT>> nvk_hash;
+    nvk_hash.allocate(pb, "nvk_hash");
+    verification_key_variable nvk(pb, num_inputs, "nvk");
+    libzecale::verification_key_scalar_hash_gadget<wppT, nverifierT>
+        nvk_hash_gadget(pb, nvk, nvk_hash, "nvk_hash_gadget");
+
+    nvk.generate_r1cs_constraints();
+    nvk_hash_gadget.generate_r1cs_constraints();
+
+    nvk.generate_r1cs_witness(vk);
+    nvk_hash_gadget.generate_r1cs_witness();
+
+    return pb.val(nvk_hash);
+}
+
+// verification_key_hash_gadget
+
 template<typename wppT, typename nverifierT, typename hashT>
 verification_key_hash_gadget<wppT, nverifierT, hashT>::
     verification_key_hash_gadget(

--- a/libzecale/tests/aggregator/aggregator_dummy_test.cpp
+++ b/libzecale/tests/aggregator/aggregator_dummy_test.cpp
@@ -15,10 +15,6 @@
 
 using namespace libzecale;
 
-template<typename wppT> using full_hash = libzeth::BLAKE2s_256<libff::Fr<wppT>>;
-template<typename wppT>
-using null_hash = libzecale::null_hash_gadget<libff::Fr<wppT>>;
-
 namespace
 {
 
@@ -49,7 +45,6 @@ template<
     typename wppT,
     typename wsnarkT,
     typename nverifierT,
-    typename hashT,
     size_t batch_size>
 void test_aggregator_with_batch(
     const size_t num_inputs_per_nested_proof,
@@ -59,8 +54,7 @@ void test_aggregator_with_batch(
         typename nverifierT::snark,
         batch_size> &batch,
     const typename wsnarkT::keypair &wkeypair,
-    aggregator_circuit<wppT, wsnarkT, nverifierT, hashT, batch_size>
-        &aggregator,
+    aggregator_circuit<wppT, wsnarkT, nverifierT, batch_size> &aggregator,
     const std::array<libff::Fr<wppT>, batch_size> &expected_results)
 {
     using npp = libzecale::other_curve<wppT>;
@@ -80,7 +74,7 @@ void test_aggregator_with_batch(
 
     // Check the nested vk hash
     libff::Fr<wppT> expect_nested_vk_hash =
-        verification_key_hash_gadget<wppT, nverifierT, hashT>::compute_hash(
+        verification_key_scalar_hash_gadget<wppT, nverifierT>::compute_hash(
             nkp.vk, num_inputs_per_nested_proof);
     ASSERT_EQ(expect_nested_vk_hash, winputs[winput_idx]);
     ++winput_idx;
@@ -100,7 +94,7 @@ void test_aggregator_with_batch(
     }
 }
 
-template<typename wppT, typename wsnarkT, typename nverifierT, typename hashT>
+template<typename wppT, typename wsnarkT, typename nverifierT>
 void test_aggregate_dummy_application()
 {
     using npp = other_curve<wppT>;
@@ -126,7 +120,7 @@ void test_aggregate_dummy_application()
     npf2.write_json(std::cout);
 
     // Wrapper keypair
-    aggregator_circuit<wppT, wsnarkT, nverifierT, hashT, batch_size> aggregator(
+    aggregator_circuit<wppT, wsnarkT, nverifierT, batch_size> aggregator(
         public_inputs_per_proof);
     const typename wsnarkT::keypair wkeypair =
         aggregator.generate_trusted_setup();
@@ -141,7 +135,7 @@ void test_aggregate_dummy_application()
         {libff::Fr<wppT>::one(), libff::Fr<wppT>::one()});
 }
 
-template<typename wppT, typename wsnarkT, typename nverifierT, typename hashT>
+template<typename wppT, typename wsnarkT, typename nverifierT>
 void test_aggregate_dummy_application_with_invalid_proof()
 {
     using npp = other_curve<wppT>;
@@ -175,7 +169,7 @@ void test_aggregate_dummy_application_with_invalid_proof()
     npf2_invalid.write_json(std::cout);
 
     // Wrapper keypair
-    aggregator_circuit<wppT, wsnarkT, nverifierT, hashT, batch_size> aggregator(
+    aggregator_circuit<wppT, wsnarkT, nverifierT, batch_size> aggregator(
         public_inputs_per_proof);
     const typename wsnarkT::keypair wkeypair =
         aggregator.generate_trusted_setup();
@@ -195,12 +189,11 @@ TEST(AggregatorTest, AggregateDummyApplicationMnt4Groth16Mnt6Groth16)
     using wpp = libff::mnt6_pp;
     using wsnark = libzeth::groth16_snark<wpp>;
     using nverifier = groth16_verifier_parameters<wpp>;
-    test_aggregate_dummy_application<wpp, wsnark, nverifier, null_hash<wpp>>();
+    test_aggregate_dummy_application<wpp, wsnark, nverifier>();
     test_aggregate_dummy_application_with_invalid_proof<
         wpp,
         wsnark,
-        nverifier,
-        null_hash<wpp>>();
+        nverifier>();
 }
 
 TEST(AggregatorTest, AggregateDummyApplicationBls12Groth16Bw6Groth16)
@@ -208,12 +201,11 @@ TEST(AggregatorTest, AggregateDummyApplicationBls12Groth16Bw6Groth16)
     using wpp = libff::bw6_761_pp;
     using wsnark = groth16_snark<wpp>;
     using nverifier = groth16_verifier_parameters<wpp>;
-    test_aggregate_dummy_application<wpp, wsnark, nverifier, null_hash<wpp>>();
+    test_aggregate_dummy_application<wpp, wsnark, nverifier>();
     test_aggregate_dummy_application_with_invalid_proof<
         wpp,
         wsnark,
-        nverifier,
-        null_hash<wpp>>();
+        nverifier>();
 }
 
 TEST(AggregatorTest, AggregateDummyApplicationBls12Groth16Bw6Pghr13)
@@ -221,12 +213,11 @@ TEST(AggregatorTest, AggregateDummyApplicationBls12Groth16Bw6Pghr13)
     using wpp = libff::bw6_761_pp;
     using wsnark = libzeth::pghr13_snark<wpp>;
     using nverifier = groth16_verifier_parameters<wpp>;
-    test_aggregate_dummy_application<wpp, wsnark, nverifier, null_hash<wpp>>();
+    test_aggregate_dummy_application<wpp, wsnark, nverifier>();
     test_aggregate_dummy_application_with_invalid_proof<
         wpp,
         wsnark,
-        nverifier,
-        null_hash<wpp>>();
+        nverifier>();
 }
 
 } // namespace

--- a/libzecale/tests/aggregator/aggregator_test.cpp
+++ b/libzecale/tests/aggregator/aggregator_test.cpp
@@ -63,8 +63,6 @@ static const size_t batch_size = 2;
 // [Root, NullifierS(2), CommitmentS(2), h_sig, h_iS(2), Residual Field,
 // Element]
 static const size_t num_zeth_inputs = 1;
-template<typename wppT>
-using nested_key_hash = libzecale::null_hash_gadget<libff::Fr<wppT>>;
 
 using namespace libzecale;
 
@@ -223,12 +221,8 @@ libzeth::extended_proof<nppT, snarkT> generate_valid_zeth_proof(
 /// We use the same SNARK for simplicity.
 template<typename wppT, typename wsnarkT, typename nverifierT>
 bool test_valid_aggregation_batch_proofs(
-    aggregator_circuit<
-        wppT,
-        wsnarkT,
-        nverifierT,
-        nested_key_hash<wppT>,
-        batch_size> &aggregator_prover,
+    aggregator_circuit<wppT, wsnarkT, nverifierT, batch_size>
+        &aggregator_prover,
     typename wsnarkT::keypair &aggregator_keypair,
     typename nverifierT::snark::keypair &zeth_keypair,
     const std::array<
@@ -307,13 +301,8 @@ void aggregator_test()
 
     std::cout << "[DEBUG] Before creation of the Aggregator prover"
               << std::endl;
-    aggregator_circuit<
-        wppT,
-        wsnarkT,
-        nverifierT,
-        nested_key_hash<wppT>,
-        batch_size>
-        aggregator_prover(num_zeth_inputs);
+    aggregator_circuit<wppT, wsnarkT, nverifierT, batch_size> aggregator_prover(
+        num_zeth_inputs);
     std::cout << "[DEBUG] Before gen Aggregator setup" << std::endl;
     typename wsnarkT::keypair aggregator_keypair =
         aggregator_prover.generate_trusted_setup();

--- a/libzecale/tests/circuits/groth16_verifier_circuit_test.cpp
+++ b/libzecale/tests/circuits/groth16_verifier_circuit_test.cpp
@@ -49,21 +49,16 @@ void test_verifier(
 
     const size_t elt_size = FieldT_A::size_in_bits();
     const size_t primary_input_size_in_bits = elt_size * primary_input_size;
-    const size_t vk_size_in_bits =
-        r1cs_gg_ppzksnark_verification_key_variable<ppT_B>::size_in_bits(
-            primary_input_size);
 
     libsnark::protoboard<FieldT_B> pb;
-    libsnark::pb_variable_array<FieldT_B> vk_bits;
-    vk_bits.allocate(pb, vk_size_in_bits, "vk_bits");
 
     libsnark::pb_variable_array<FieldT_B> primary_input_bits;
     primary_input_bits.allocate(
         pb, primary_input_size_in_bits, "primary_input_bits");
 
     r1cs_gg_ppzksnark_proof_variable<ppT_B> proof(pb, "proof");
-    r1cs_gg_ppzksnark_verification_key_variable<ppT_B> vk(
-        pb, vk_bits, primary_input_size, "vk");
+    r1cs_gg_ppzksnark_verification_key_scalar_variable<ppT_B> vk(
+        pb, primary_input_size, "vk");
 
     libsnark::pb_variable<FieldT_B> result;
     result.allocate(pb, "result");

--- a/libzecale/tests/circuits/verification_key_hash_gadget_test.cpp
+++ b/libzecale/tests/circuits/verification_key_hash_gadget_test.cpp
@@ -4,6 +4,8 @@
 
 #include "libzecale/circuits/groth16_verifier/groth16_verifier_parameters.hpp"
 #include "libzecale/circuits/pairing/bw6_761_pairing_params.hpp"
+#include "libzecale/circuits/pairing/mnt_pairing_params.hpp"
+#include "libzecale/circuits/pghr13_verifier/pghr13_verifier_parameters.hpp"
 #include "libzecale/circuits/verification_key_hash_gadget.hpp"
 #include "libzecale/tests/circuits/dummy_application.hpp"
 
@@ -15,8 +17,134 @@
 namespace
 {
 
+template<typename wppT, typename nverifierT>
+static void verification_key_scalar_hash_test()
+{
+    using FieldT = libff::Fr<wppT>;
+    using npp = libzecale::other_curve<wppT>;
+    using nsnark = typename nverifierT::snark;
+
+    // Get 2 VKs for the dummy app, and determine the number of primary inputs.
+    libzecale::test::dummy_app_wrapper<npp, nsnark> dummy_app;
+    const size_t num_inputs =
+        libzecale::test::dummy_app_wrapper<npp, nsnark>::num_primary_inputs;
+    const typename nsnark::keypair nkeypair1 = dummy_app.generate_keypair();
+    const typename nsnark::keypair nkeypair2 = dummy_app.generate_keypair();
+
+    // Compute the digest of each key, as a scalar.
+    const FieldT vk1_hash =
+        libzecale::verification_key_scalar_hash_gadget<wppT, nverifierT>::
+            compute_hash(nkeypair1.vk, num_inputs);
+    const FieldT vk2_hash =
+        libzecale::verification_key_scalar_hash_gadget<wppT, nverifierT>::
+            compute_hash(nkeypair2.vk, num_inputs);
+
+    // The digests should be non-zero, and different from each other with
+    // overwhelming probability.
+    ASSERT_NE(FieldT::zero(), vk1_hash);
+    ASSERT_NE(FieldT::zero(), vk2_hash);
+    ASSERT_NE(vk1_hash, vk2_hash);
+}
+
+TEST(VerificationKeyHashTest, ScalarHashTestBW6_761Groth16)
+{
+    using wpp = libff::bw6_761_pp;
+    verification_key_scalar_hash_test<
+        wpp,
+        libzecale::groth16_verifier_parameters<wpp>>();
+}
+
+TEST(VerificationKeyHashTest, ScalarHashTestBW6_761Pghr13)
+{
+    using wpp = libff::bw6_761_pp;
+    verification_key_scalar_hash_test<
+        wpp,
+        libzecale::pghr13_verifier_parameters<wpp>>();
+}
+
+template<typename wppT, typename nverifierT>
+void verification_key_scalar_hash_gadget_test()
+{
+    using FieldT = libff::Fr<wppT>;
+    using npp = libzecale::other_curve<wppT>;
+    using nsnark = typename nverifierT::snark;
+
+    const size_t num_nested_inputs =
+        libzecale::test::dummy_app_wrapper<npp, nsnark>::num_primary_inputs;
+    libzecale::test::dummy_app_wrapper<npp, nsnark> dummy_app;
+    const typename nsnark::keypair nkeypair = dummy_app.generate_keypair();
+
+    // Compute the hash via the static compute method.
+    const FieldT nvk_hash_value =
+        libzecale::verification_key_scalar_hash_gadget<wppT, nverifierT>::
+            compute_hash(nkeypair.vk, num_nested_inputs);
+
+    // Set up a protoboard with hash as primary input.
+    libsnark::protoboard<FieldT> pb;
+    libsnark::pb_variable<libff::Fr<wppT>> nvk_hash;
+    nvk_hash.allocate(pb, "nvk_hash");
+    pb.set_input_sizes(1);
+
+    // Verification key
+    typename nverifierT::verification_key_scalar_variable_gadget nvk(
+        pb, num_nested_inputs, "nvk");
+
+    // Gadget to check the hash
+    libzecale::verification_key_scalar_hash_gadget<wppT, nverifierT>
+        nvk_hash_gadget(pb, nvk, nvk_hash, "nvk_scalar_hash_gadget");
+
+    // Constraints
+    nvk.generate_r1cs_constraints();
+    nvk_hash_gadget.generate_r1cs_constraints();
+
+    // Witness
+    nvk.generate_r1cs_witness(nkeypair.vk);
+    nvk_hash_gadget.generate_r1cs_witness();
+
+    // Show final hash value in Fr<wppT>.
+    const libff::Fr<wppT> hash_value = pb.val(nvk_hash);
+    std::cout << "\nVK scalar hash value: ";
+    libzeth::field_element_write_json(hash_value, std::cout);
+    std::cout << "\n";
+
+    ASSERT_EQ(nvk_hash_value, hash_value);
+    ASSERT_NE(FieldT::zero(), hash_value);
+}
+
+TEST(VerificationKeyHashTest, ScalarHashGadgetTestBW6_761Groth16)
+{
+    using wpp = libff::bw6_761_pp;
+    verification_key_scalar_hash_gadget_test<
+        wpp,
+        libzecale::groth16_verifier_parameters<wpp>>();
+}
+
+TEST(VerificationKeyHashTest, ScalarHashGadgetTestBW6_761Pghr13)
+{
+    using wpp = libff::bw6_761_pp;
+    verification_key_scalar_hash_gadget_test<
+        wpp,
+        libzecale::pghr13_verifier_parameters<wpp>>();
+}
+
+TEST(VerificationKeyHashTest, ScalarHashGadgetTestMNT4Groth16)
+{
+    using wpp = libff::mnt4_pp;
+    verification_key_scalar_hash_gadget_test<
+        wpp,
+        libzecale::groth16_verifier_parameters<wpp>>();
+}
+
+TEST(VerificationKeyHashTest, ScalarHashGadgetTestMNT6Groth16)
+{
+    using wpp = libff::mnt6_pp;
+    verification_key_scalar_hash_gadget_test<
+        wpp,
+        libzecale::groth16_verifier_parameters<wpp>>();
+}
+
 template<typename wppT, typename nverifierT, typename hash_gadgetT>
-void verification_key_hash_test()
+static void verification_key_hash_test()
 {
     using FieldT = libff::Fr<wppT>;
     using npp = libzecale::other_curve<wppT>;
@@ -101,6 +229,15 @@ void verification_key_hash_gadget_test()
     ASSERT_EQ(nvk_hash_value, hash_value);
 }
 
+TEST(VerificationKeyHashTest, HashTest)
+{
+    using wpp = libff::bw6_761_pp;
+    verification_key_hash_test<
+        wpp,
+        libzecale::groth16_verifier_parameters<wpp>,
+        libzeth::BLAKE2s_256<libff::Fr<wpp>>>();
+}
+
 TEST(VerificationKeyHashTest, HashGadgetTest)
 {
     using wpp = libff::bw6_761_pp;
@@ -116,6 +253,8 @@ int main(int argc, char **argv)
 {
     libff::bw6_761_pp::init_public_params();
     libff::bls12_377_pp::init_public_params();
+    libff::mnt4_pp::init_public_params();
+    libff::mnt6_pp::init_public_params();
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
- Use the mimc-based hash for the nested verification key.
- Requires a modification fo the verification key object, and a `scalar` versio nof the vk hashing gadget
- Large number of bit variables in VK are no longer required, so `scalar` versions of these objects have been added.
 