### PR TITLE
Use full vk digest in applications (depends on #66)

### DIFF
--- a/client/zecale/cli/zecale_nested_verification_key_hash.py
+++ b/client/zecale/cli/zecale_nested_verification_key_hash.py
@@ -4,7 +4,6 @@
 
 from zecale.cli.command_context import CommandContext
 from zecale.cli.utils import load_verification_key
-from zeth.core.utils import hex_to_uint256_list
 from click import command, argument, Context, pass_context
 
 
@@ -25,15 +24,4 @@ def nested_verification_key_hash(
     vk = load_verification_key(snark, verification_key_file)
     aggregator_client = cmd_ctx.get_aggregator_client()
     vk_hash_hex = aggregator_client.get_nested_verification_key_hash(snark, vk)
-
-    # Use the lowest order uint256_t for the client application. (The wrapping
-    # zk-snark still uses the full width hash, which is returned by the
-    # aggregation server as a primary input when a batch is created).
-    vk_hash_evm = list(hex_to_uint256_list(vk_hash_hex))
-    vk_hash = vk_hash_evm[-1]
-
-    # TODO: pass the full-width vk_hash to to the application (requires the
-    # dispatch interface to be updated), or show that using the LO word
-    # is still collision resistant.
-
-    print(vk_hash.to_bytes(32, byteorder='big').hex())
+    print(vk_hash_hex)

--- a/client/zecale/dummy_app/deploy.py
+++ b/client/zecale/dummy_app/deploy.py
@@ -47,9 +47,8 @@ def deploy(
         dispatcher_desc = InstanceDescription.from_json_dict(
             json.load(dispatcher_instance_f))
 
-    # Assume there is only one evm word
-    verification_key_hash_evm = next(
-        iter(hex_to_uint256_list(verification_key_hash)))
+    # Verification key hash as an array of evm words.
+    verification_key_hash_evm = list(hex_to_uint256_list(verification_key_hash))
     print(f"verification_key_hash_evm = {verification_key_hash_evm}")
 
     web3 = open_web3_from_network(eth_network)

--- a/contracts/DummyApplication.sol
+++ b/contracts/DummyApplication.sol
@@ -17,12 +17,12 @@ contract DummyApplication is IZecaleApplication
 
     // Hash of nested verification key for proofs associated with this
     // contract.
-    uint256 _vk_hash;
+    uint256[2] _vk_hash;
 
     // The set of scalars seen by the contract.
     mapping(uint256 => uint256) _scalars;
 
-    constructor(address permitted_dispatcher, uint256 vk_hash) public
+    constructor(address permitted_dispatcher, uint256[2] memory vk_hash) public
     {
         _permitted_dispatcher = permitted_dispatcher;
         _vk_hash = vk_hash;
@@ -33,7 +33,7 @@ contract DummyApplication is IZecaleApplication
     // demonstrated. `parameters` is the encoding of a dynamically sized array
     // of uint256s, which must have length 1.
     function dispatch(
-        uint256 vk_hash,
+        uint256[2] memory vk_hash,
         uint256[] memory inputs,
         bytes memory parameters) public payable
     {
@@ -46,7 +46,9 @@ contract DummyApplication is IZecaleApplication
 
         // Ensure that the caller and vk_hash are as expected
         require(msg.sender == _permitted_dispatcher, "dispatcher not permitted");
-        require(vk_hash == _vk_hash, "invalid vk_hash");
+        require(
+            vk_hash[0] == _vk_hash[0] && vk_hash[1] == _vk_hash[1],
+            "invalid vk_hash");
         require(0 == _scalars[inputs[0]], "scalar already seen");
 
         require(0 != param_uints[0], "param should not be 0");

--- a/contracts/DummyApplication.sol
+++ b/contracts/DummyApplication.sol
@@ -28,9 +28,10 @@ contract DummyApplication is IZecaleApplication
         _vk_hash = vk_hash;
     }
 
-    // Implementation of IZecaleApplication. Here, the single
-    // input is the scalar for which knowledge of the multiplicative inverse
-    // is demonstrated. `parameters` is currently unused.
+    // Implementation of IZecaleApplication. Here, the single input is the
+    // scalar for which knowledge of the multiplicative inverse is
+    // demonstrated. `parameters` is the encoding of a dynamically sized array
+    // of uint256s, which must have length 1.
     function dispatch(
         uint256 vk_hash,
         uint256[] memory inputs,

--- a/contracts/IZecaleApplication.sol
+++ b/contracts/IZecaleApplication.sol
@@ -19,7 +19,7 @@ contract IZecaleApplication
     // proof inputs) to be passed as part of this invocation. The
     // interpretation of these is application-defined.
     function dispatch(
-        uint256 nested_vk_hash,
+        uint256[2] memory nested_vk_hash,
         uint256[] memory nested_inputs,
         bytes memory nested_parameters) public payable;
 }

--- a/contracts/ZecaleDispatcher.sol
+++ b/contracts/ZecaleDispatcher.sol
@@ -110,7 +110,9 @@ contract ZecaleDispatcher
         // sizes).
 
         // Cache the nested VK (LO word) to pass to the application.
-        uint256 nested_vk_hash = inputs[1];
+        uint256[2] memory nested_vk_hash;
+        nested_vk_hash[0] = inputs[0];
+        nested_vk_hash[1] = inputs[1];
         uint256 inputs_per_nested_tx = _inputs_per_nested_tx;
 
         // Create an array to reuse to pass the nested inputs to the


### PR DESCRIPTION
Addresses #67
Includes update to zeth to adopt the new dispatch signature (clearmatics/zeth#349).