### PR TITLE
Fix client readme

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -46,9 +46,9 @@ $ cd $ZECALE/client
 ```
 
 We assume all further commands described here are executed from within the
-Python virtualenv.  To enter the virtualenv from a new terminal, re-run
+Python virtualenv. To enter the virtualenv from a new terminal, re-run
 ```console
-$ source env/bin/activate
+$ source $ZECALE/depends/zeth/client/env/bin/activate
 ```
 
 ## Execute unit tests

--- a/client/README.md
+++ b/client/README.md
@@ -68,14 +68,6 @@ To do so, you can start a ganache-cli instance via docker by running:
 docker run -ti -p 8545:8545 ghcr.io/clearmatics/ganache-cli --hardfork istanbul --gasLimit 0x3FFFFFFFFFFFF --gasPrice 1 --defaultBalanceEther 90000000000
 ```
 
-Otherwise, please follow the instructions below to run a modified version
-of ganache-cli in a new terminal (see [Zeth](https://github.com/clearmatics/zeth/) for more information):
-```console
-cd $ZECALE/depends/zeth/zeth_contracts
-npm install # make sure that node and npm have the right versions
-npm run testrpc
-```
-
 ## Execute testing scripts
 
 Once the `aggregator_server` and a custom `ganache-cli` instance are


### PR DESCRIPTION
- The `npm run testrpc` command was removed in: https://github.com/clearmatics/zeth/commit/1e9a3484c15e05cb3c9f6c196c7453fab61e6ca2
- The `source` command wasn't pointing to the right `activate` script
