### PR TITLE
Fixed test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,9 @@ cmake ..
 # Compile all targets
 make
 
-# (optional) Run the unit tests
-make test
-
-# (optional) Run the all tests (unit tests, syntax checks, etc)
+# (optional) Build and run the all tests (unit tests, syntax checks, etc)
 make check
+# Alternatively, run: make build_tests && make test
 
 # Start the aggregator_server process
 aggregator_server

--- a/libzecale/tests/README.md
+++ b/libzecale/tests/README.md
@@ -1,18 +1,30 @@
 # Zecale tests
 
+## Adding Tests
+
+The directory structure here should match that in libzecale, where files are named `<original_basename>_test.cpp`.
+
+Tests are built as individual executables, so must contain a minimal `main` function which invokes the tests. (See existing tests for details.)
+
 ## Run the tests
 
-```bash
-# Configure your environment by running the following command from the ${ZECALE} repo
-cd ${ZECALE}
-. ./setup_env.sh
+Execute these commands from the `build` directory:
 
-# Go in the build repository and run the following commands
-cd ${ZECALE}/build
-cmake ..
-make check # (or just "make test" if the tests are already built)
+```console
+# Build and run all tests.
+$ cmake ..
+$ make check
+```
 
-# Note: Every test can be ran independently by running the executable.
-# Example:
-application_pool_test
+Other operations can be performed as follows:
+
+```console
+# Build (but do not run) all tests
+$ make build_tests
+# Build a single test
+$ make <test-name>
+# Execute a single test
+$ <test-name>
+# Invoke tests, with verbose output on failure
+$ CTEST_OUTPUT_ON_FAILURE=1 make check
 ```


### PR DESCRIPTION
- The README mentioned "Run the unit tests by running `make test`". Following the README blindly led to undesired behavior since `make test` doesn't build the tests and all tests were failing due to their executables being missing. Clarified this
- Expended the tests/README.md following the approach used in Zeth.