### PR TITLE
Switched snake_case python CLIs to kebab-case

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -150,7 +150,7 @@ After deploying the the Zecale dispatcher, it is possible to deploy a Zecale
 application. One can use the `DummyApplication` contract as an example:
 
 ```console
-zecale_dummy_app deploy
+zecale-dummy-app deploy
 ```
 
 For a more comprehensive overview on how to use Zecale with a base

--- a/client/setup.py
+++ b/client/setup.py
@@ -25,9 +25,9 @@ setup(
     ],
     entry_points={
         'console_scripts': [
-            'zecale_dummy_app=zecale.dummy_app.__main__:dummy_app',
+            'zecale-dummy-app=zecale.dummy_app.__main__:dummy_app',
             'zecale=zecale.cli.__main__:zecale',
-            'zeth_zecale=zeth_zecale.__main__:zeth_zecale',
+            'zeth-zecale=zeth_zecale.__main__:zeth_zecale',
         ],
     }
 )

--- a/scripts/test-client
+++ b/scripts/test-client
@@ -40,7 +40,7 @@ pushd application_deployer
     [ -e zecale-instance ] || cp ../aggregator_deployer/zecale-instance .
     [ -e app-vk.json ] || cp ${TEST_DATA_DIR}/dummy_app/vk.json app-vk.json
     [ -e vk-hash ] || zecale nested-verification-key-hash app-vk.json > vk-hash
-    [ -e app-instance ] || zecale_dummy_app deploy `cat vk-hash`
+    [ -e app-instance ] || zecale-dummy-app deploy `cat vk-hash`
 
     zecale register --key app-vk.json --name ${APP_NAME} || echo -n
     # Re-registration should fail
@@ -48,10 +48,10 @@ pushd application_deployer
         (echo Expected duplicate registration to fail; exit 1)
 
     echo Check starting app state
-    zecale_dummy_app get 7 --check 0
-    zecale_dummy_app get 8 --check 0
-    zecale_dummy_app get 9 --check 0
-    zecale_dummy_app get 10 --check 0
+    zecale-dummy-app get 7 --check 0
+    zecale-dummy-app get 8 --check 0
+    zecale-dummy-app get 9 --check 0
+    zecale-dummy-app get 10 --check 0
 popd # application_deployer
 
 # Submit 4 transactions to the aggregator (enough for 2 batches)
@@ -75,10 +75,10 @@ pushd user1
     zecale submit-batch batch1.json --wait
 
     echo Check app state after batch 1
-    zecale_dummy_app get 7 --check 23
-    zecale_dummy_app get 8 --check 24
-    zecale_dummy_app get 9 --check 0
-    zecale_dummy_app get 10 --check 0
+    zecale-dummy-app get 7 --check 23
+    zecale-dummy-app get 8 --check 24
+    zecale-dummy-app get 9 --check 0
+    zecale-dummy-app get 10 --check 0
 
     # get a second batch and send to the contract
     zecale get-batch --name ${APP_NAME} --batch-file batch2.json
@@ -86,10 +86,10 @@ pushd user1
     zecale submit-batch batch2.json --wait
 
     echo Check app state after batch 2
-    zecale_dummy_app get 7 --check 23
-    zecale_dummy_app get 8 --check 24
-    zecale_dummy_app get 9 --check 25
-    zecale_dummy_app get 10 --check 26
+    zecale-dummy-app get 7 --check 23
+    zecale-dummy-app get 8 --check 24
+    zecale-dummy-app get 9 --check 25
+    zecale-dummy-app get 10 --check 26
 
     # A third batch should be available
     zecale get-batch --name ${APP_NAME} --batch-file batch3.json && \

--- a/scripts/test-zeth-zecale
+++ b/scripts/test-zeth-zecale
@@ -74,7 +74,7 @@ pushd zeth_deployer
          --in ${note_id_1} \
          --out zeth-address.pub,25 \
          --out zeth-address.pub,25
-    zeth_zecale create-nested-tx zeth_tx1.json -o nested_zeth_tx1.json
+    zeth-zecale create-nested-tx zeth_tx1.json -o nested_zeth_tx1.json
     zecale submit nested_zeth_tx1.json
 
     zeth mix --for-dispatch-call \
@@ -84,7 +84,7 @@ pushd zeth_deployer
          --in ${note_id_2} \
          --out zeth-address.pub,25 \
          --out zeth-address.pub,25
-    zeth_zecale create-nested-tx zeth_tx2.json -o nested_zeth_tx2.json
+    zeth-zecale create-nested-tx zeth_tx2.json -o nested_zeth_tx2.json
     zecale submit nested_zeth_tx2.json
 
     # Create a batch


### PR DESCRIPTION
As the name indicates, there were a few Python commands still using snake_case. This PR fixes this and sticks the to convention (kebab-case).